### PR TITLE
Fix/avoid double go2rtc simultaneous process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+
 env:
   RTK_DISABLE: "1"
 
@@ -57,3 +60,162 @@ jobs:
 
       - name: Run tests
         run: just test
+
+  build-dmg:
+    name: Build ad-hoc DMG (${{ matrix.arch }})
+    needs: lint-test
+    if: github.event_name == 'pull_request'
+    runs-on: macos-26
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        arch: [arm64, x86_64]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read pinned Xcode version
+        id: xcode-pin
+        run: echo "version=$(cat .xcode-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ steps.xcode-pin.outputs.version }}
+
+      - name: Install Homebrew tooling
+        run: |
+          brew update
+          brew install just xcodegen create-dmg
+
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: ${{ runner.os }}-deriveddata-${{ hashFiles('project.yml', 'PrusaStatusBar/**/*.swift', 'PrusaStatusBarTests/**/*.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-deriveddata-
+
+      - name: Cache go2rtc helper
+        uses: actions/cache@v4
+        with:
+          path: PrusaStatusBar/Resources/go2rtc
+          key: go2rtc-${{ matrix.arch }}-${{ hashFiles('scripts/fetch-go2rtc.sh') }}
+
+      - name: Resolve metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          PR_NUM=${{ github.event.pull_request.number }}
+          SHORT_SHA=$(git rev-parse --short=7 HEAD)
+          VERSION=$(grep -E '^[[:space:]]*MARKETING_VERSION:' project.yml | head -n1 | sed -E 's/.*MARKETING_VERSION:[[:space:]]*"([^"]+)".*/\1/')
+          DMG_NAME="PrusaStatusBar-${VERSION}-pr${PR_NUM}-${SHORT_SHA}-${{ matrix.arch }}.dmg"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dmg_name=${DMG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "DMG_NAME=${DMG_NAME}" >> "$GITHUB_ENV"
+
+      - name: Fetch bundled go2rtc helper (${{ matrix.arch }})
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: ./scripts/fetch-go2rtc.sh
+
+      - name: Generate Xcode project
+        run: just gen
+
+      - name: Build Release .app (${{ matrix.arch }})
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project PrusaStatusBar.xcodeproj \
+            -scheme PrusaStatusBar \
+            -configuration Release \
+            -derivedDataPath build \
+            ARCHS="${{ matrix.arch }}" \
+            ONLY_ACTIVE_ARCH=NO \
+            MARKETING_VERSION="${VERSION}" \
+            CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="-" \
+            DEVELOPMENT_TEAM="" \
+            clean build
+          lipo -info "build/Build/Products/Release/PrusaStatusBar.app/Contents/MacOS/PrusaStatusBar"
+
+      - name: Package DMG (ad-hoc signed)
+        run: |
+          set -euo pipefail
+          ./scripts/make-dmg.sh \
+            "build/Build/Products/Release/PrusaStatusBar.app" \
+            "${DMG_NAME}"
+
+      - name: Compute sha256
+        run: |
+          SHA256=$(shasum -a 256 "${DMG_NAME}" | cut -d ' ' -f1)
+          echo "${SHA256}" > "${DMG_NAME}.sha256"
+          echo "sha256(${DMG_NAME})=${SHA256}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-${{ github.event.pull_request.number }}-dmg-${{ matrix.arch }}
+          path: |
+            ${{ env.DMG_NAME }}
+            ${{ env.DMG_NAME }}.sha256
+          if-no-files-found: error
+          retention-days: 30
+
+  comment-pr:
+    name: Comment on PR with artifact links
+    needs: build-dmg
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post beta build comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.sha.substring(0, 7);
+            const prNum = context.payload.pull_request.number;
+            const body = [
+              '<!-- beta-build-comment -->',
+              '## Beta build ready',
+              '',
+              `Ad-hoc signed DMGs for commit \`${sha}\` -- download from [this Actions run](${runUrl}) (Artifacts section at the bottom).`,
+              '',
+              '| Artifact | Architecture |',
+              '|---|---|',
+              `| \`pr-${prNum}-dmg-arm64\` | Apple Silicon (M1/M2/M3/M4) |`,
+              `| \`pr-${prNum}-dmg-x86_64\` | Intel |`,
+              '',
+              '**Gatekeeper bypass required** (ad-hoc signed, not notarized):',
+              '```bash',
+              'xattr -dr com.apple.quarantine /Applications/PrusaStatusBar.app',
+              '```',
+              'Or: right-click the app > Open > Open (two-step, first time only).',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNum,
+            });
+            const existing = comments.find(c => c.body.includes('<!-- beta-build-comment -->'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNum,
+                body,
+              });
+            }

--- a/PrusaStatusBar/Services/GoRTCService.swift
+++ b/PrusaStatusBar/Services/GoRTCService.swift
@@ -2,19 +2,30 @@ import Darwin
 import Foundation
 import os
 
-/// PGID slot read by the C-level `atexit` fallback. Updated by
-/// `GoRTCService.start` and cleared by `GoRTCService.stop`. Lives at file
-/// scope because `atexit` accepts a C function pointer with no captures.
+/// PGID slot read by the C-level `atexit` fallback. Set to the helper's
+/// pid after a successful `setpgid(pid, pid)` so a group kill covers any
+/// descendants. Zero when `setpgid` was not attempted or failed.
 private nonisolated(unsafe) var goRTCTrackedPGID: pid_t = 0
 
-/// `atexit` handler. Touches only the C global above so it is safe to call
-/// from any termination path, including ones that bypass Swift runtime
-/// teardown. Sends SIGKILL to the helper's process group if we have one.
+/// Raw PID of the running helper. Always set regardless of whether
+/// `setpgid` succeeded. Used by the atexit fallback as a direct-kill
+/// backstop for sandboxed runs where `setpgid` returns EPERM.
+private nonisolated(unsafe) var goRTCTrackedPID: pid_t = 0
+
+/// `atexit` handler. Touches only the C globals above so it is safe to
+/// call from any termination path, including ones that bypass Swift runtime
+/// teardown. Tries a process-group kill first (covers descendants when
+/// `setpgid` succeeded), then falls back to a direct-PID kill so the
+/// helper dies even when the App Sandbox blocked `setpgid`.
 @_cdecl("prusaStatusBarGoRTCAtexit")
 func prusaStatusBarGoRTCAtexit() {
     let pgid = goRTCTrackedPGID
     if pgid > 0 {
         _ = Darwin.kill(-pgid, SIGKILL)
+    }
+    let pid = goRTCTrackedPID
+    if pid > 0 {
+        _ = Darwin.kill(pid, SIGKILL)
     }
 }
 
@@ -101,8 +112,13 @@ final class GoRTCService {
     /// Idempotent: returns the HLS URL for the given RTSP source. If the
     /// helper is already running for the same RTSP URL, no work is done.
     /// Otherwise the helper is restarted with the new config.
+    ///
+    /// go2rtc defaults to UDP transport for RTSP. Many cameras (and some
+    /// routers) block UDP RTSP or only support TCP. Forcing TCP via the
+    /// go2rtc URL fragment makes the Buddy camera work in the same
+    /// conditions where VLC (which defaults to TCP) succeeds.
     func hlsURL(forRTSP rtsp: String) -> URL? {
-        upsertStream(name: Self.snapshotBuddyStreamName, source: rtsp)
+        upsertStream(name: Self.snapshotBuddyStreamName, source: withTCPTransport(rtsp))
     }
 
     /// Generic-camera variant: accepts any source go2rtc can transmux
@@ -141,6 +157,7 @@ final class GoRTCService {
         guard let helper = dependencies.helperURL() else { return }
         let needsRestart = process?.isRunning != true || streams != currentStreams
         guard needsRestart else { return }
+        killOrphanIfNeeded()
         stop()
         do {
             try start(helper: helper, streams: streams)
@@ -164,6 +181,7 @@ final class GoRTCService {
         guard let proc = process else {
             currentStreams = [:]
             goRTCTrackedPGID = 0
+            goRTCTrackedPID = 0
             removePIDFile()
             return
         }
@@ -171,6 +189,7 @@ final class GoRTCService {
         currentStreams = [:]
         let pgid = goRTCTrackedPGID
         goRTCTrackedPGID = 0
+        goRTCTrackedPID = 0
 
         guard proc.isRunning else {
             removePIDFile()
@@ -217,7 +236,7 @@ final class GoRTCService {
         // SIGKILL whatever process happens to inherit the recycled id.
         if pidLooksLikeHelper(pid) {
             logger.info("Reaping orphan go2rtc pid=\(pid, privacy: .public)")
-            _ = Darwin.kill(-pid, SIGKILL)
+            _ = Darwin.kill(pid, SIGKILL)
             // Wait briefly for the kernel to tear it down. waitpid is not
             // available since the process is not our child anymore.
             let deadline = Date().addingTimeInterval(0.5)
@@ -256,11 +275,13 @@ final class GoRTCService {
         // kill(-pgid, SIGKILL) downstream covers any descendants. Calling
         // setpgid from the parent right after run() is race-safe, the child
         // is already fork-execed.
-        if setpgid(pid, pid) != 0 {
+        if setpgid(pid, pid) == 0 {
+            goRTCTrackedPGID = pid
+        } else {
             let err = errno
             logger.warning("setpgid failed pid=\(pid, privacy: .public) errno=\(err, privacy: .public)")
         }
-        goRTCTrackedPGID = pid
+        goRTCTrackedPID = pid
         writePIDFile(pid: pid)
         logger.info("go2rtc launched, pid=\(pid, privacy: .public)")
     }
@@ -351,6 +372,41 @@ final class GoRTCService {
 /// `GoRTCService`'s body under the lint budget. Same-file extension so
 /// `private` access stays intact.
 extension GoRTCService {
+    /// Appends `#transport=tcp` to an RTSP URL for go2rtc. If a fragment
+    /// already exists the parameter is appended with `&` so existing
+    /// go2rtc options are preserved.
+    func withTCPTransport(_ rtsp: String) -> String {
+        guard rtsp.lowercased().hasPrefix("rtsp") else { return rtsp }
+        guard let hashIndex = rtsp.firstIndex(of: "#") else {
+            return "\(rtsp)#transport=tcp"
+        }
+        let fragment = String(rtsp[rtsp.index(after: hashIndex)...])
+        let hasTransport = fragment.split(separator: "&").contains {
+            $0.split(separator: "=", maxSplits: 1).first.map(String.init) == "transport"
+        }
+        return hasTransport ? rtsp : "\(rtsp)&transport=tcp"
+    }
+
+    /// Reads the PID file written by the previous app session and sends
+    /// SIGKILL to the recorded process if it is still alive and the path
+    /// of that process matches the bundled helper binary. This prevents an
+    /// orphaned go2rtc (left behind by a crash or force-quit, where the
+    /// atexit SIGKILL could not reach it because `setpgid` is blocked by
+    /// the App Sandbox) from holding port \(dependencies.port) and blocking
+    /// a fresh start.
+    func killOrphanIfNeeded() {
+        guard
+            let raw = try? String(contentsOf: dependencies.pidFileURL, encoding: .utf8),
+            let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
+            pid != process?.processIdentifier,
+            isProcessAlive(pid),
+            pidLooksLikeHelper(pid)
+        else { return }
+        logger.warning("killing orphaned go2rtc pid=\(pid, privacy: .public)")
+        Darwin.kill(pid, SIGKILL)
+        removePIDFile()
+    }
+
     func isPortBound(_ port: UInt16) -> Bool {
         let socketFD = Darwin.socket(AF_INET, SOCK_STREAM, 0)
         guard socketFD >= 0 else { return false }

--- a/PrusaStatusBar/UI/Components/CameraPlayer.swift
+++ b/PrusaStatusBar/UI/Components/CameraPlayer.swift
@@ -56,7 +56,12 @@
         /// AVPlayer hits it during that window the AVPlayerItem flips to
         /// .failed and never retries on its own, leaving a dark tile. We
         /// re-attempt with linear backoff up to a short cap.
-        private let retryBackoffs: [TimeInterval] = [0.4, 0.7, 1.0, 1.5, 2.0, 2.5]
+        ///
+        /// Extended to cover cameras with slow RTSP keyframe intervals: go2rtc
+        /// needs at least one keyframe before generating the first HLS segment.
+        /// With a 2-5s keyframe interval plus RTSP connection time, the
+        /// original 8.1s budget was too tight. 23s covers most real cameras.
+        private let retryBackoffs: [TimeInterval] = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0]
 
         override init(frame frameRect: NSRect) {
             super.init(frame: frameRect)


### PR DESCRIPTION
<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

On some specific cases (crashes/tests), go2rtc can be run multiple time leading to camera not being able to show properly the image.

## Checklist

- [X] Tests added or updated (Swift Testing).
- [X] `just check` passes locally.
- [X] `just test` passes locally.
- [X] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [X] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Ensure the bundled go2rtc helper is reliably single-instance, killed on app termination or restart, and more robust against sandbox limitations, while improving camera connection reliability and CI ergonomics.

Bug Fixes:
- Prevent orphaned or duplicate go2rtc helper processes from surviving crashes or restarts by tracking and killing previous instances via PID files and atexit fallbacks.
- Avoid failure to terminate go2rtc when App Sandbox blocks process group setup by tracking and killing the raw PID in addition to the process group.
- Increase camera playback resilience by extending retry timing so streams with slow keyframe intervals can start reliably.

Enhancements:
- Force TCP transport for RTSP snapshot streams to improve compatibility with cameras and networks that block UDP-based RTSP.
- Adjust orphan process reaping to target the helper PID directly instead of its process group for safer cleanup behavior.

CI:
- Extend the CI workflow to build ad-hoc signed DMG artifacts for both Apple Silicon and Intel on pull requests and automatically comment on PRs with download instructions for the generated beta builds.