### PR TITLE
feat: allow the menu bar to become a dedicated floating window #5

### DIFF
--- a/PrusaStatusBar.xcodeproj/project.pbxproj
+++ b/PrusaStatusBar.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		9892F61C7B50D5C7750441C4 /* PreferencesWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796B7A9C12A1BD276619A187 /* PreferencesWindow.swift */; };
 		99B85BE321C085470AAA8E3A /* UserPreferences+CustomActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DAA7E6CB94AE41C7F7F1F4 /* UserPreferences+CustomActions.swift */; };
 		9E01EB023DBAC132FB582F76 /* NotificationImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 677AAEE9702751F9456E3BEC /* NotificationImage.swift */; };
+		9FC2324164CC9C9EE1FE1291 /* DetachedStatusWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACFA947C53AC9CAE9FF98676 /* DetachedStatusWindowController.swift */; };
 		A0DE1BFC96C9E59CF114A748 /* GenericCameraSecretsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF255CDB91261E22B5F0312B /* GenericCameraSecretsStore.swift */; };
 		A2222D92E07DCD175FE7D55D /* ActionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AD37CACC6D40ACD57C9AEF /* ActionsSection.swift */; };
 		A572439161C5663B19496F00 /* DisconnectedIconStylePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74880505D4E63902C3FBF7 /* DisconnectedIconStylePicker.swift */; };
@@ -327,6 +328,7 @@
 		A303204F7FC35BF4C5E85133 /* AppServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServices.swift; sourceTree = "<group>"; };
 		A92BE5989CA4A26FD7C81AA6 /* CameraSnapshotProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraSnapshotProvider.swift; sourceTree = "<group>"; };
 		AB7B10A1654B203C7A0820F3 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/Localizable.strings; sourceTree = "<group>"; };
+		ACFA947C53AC9CAE9FF98676 /* DetachedStatusWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetachedStatusWindowController.swift; sourceTree = "<group>"; };
 		AF81764CEABA7BE23C1BD196 /* AnimatedPercentChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedPercentChip.swift; sourceTree = "<group>"; };
 		B03914CD423E3ECC98299E70 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B068DF8D99041051EFC7FA85 /* UpdateCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCheckerTests.swift; sourceTree = "<group>"; };
@@ -504,6 +506,7 @@
 				7C4F1262C4A586437574B9D7 /* CameraQuickLookWindowController.swift */,
 				66815EE5A404BDEE764B0EDC /* CameraStreamKeepalive.swift */,
 				6EBD690F68E4ED1C0EEE8583 /* CustomActionsSection.swift */,
+				ACFA947C53AC9CAE9FF98676 /* DetachedStatusWindowController.swift */,
 				B92321F45A3CC1E75D6D9CDB /* DropdownView.swift */,
 				D5E3A827E5B85503CE799041 /* DropdownView+CustomActions.swift */,
 				7D413B5006C1449975021ED6 /* GeneralTab.swift */,
@@ -875,6 +878,7 @@
 				CF5BED69B30E01A19FE8DE07 /* CustomActionSlotCard.swift in Sources */,
 				37B645A9E57F74D3865BE7E5 /* CustomActionsRow.swift in Sources */,
 				5BF470FA703D65D9BC9DAD5D /* CustomActionsSection.swift in Sources */,
+				9FC2324164CC9C9EE1FE1291 /* DetachedStatusWindowController.swift in Sources */,
 				A572439161C5663B19496F00 /* DisconnectedIconStylePicker.swift in Sources */,
 				86B855EEA0F810E156D4B2B6 /* DropdownView+CustomActions.swift in Sources */,
 				ADB0C7E9F133CCDF2809B11C /* DropdownView.swift in Sources */,

--- a/PrusaStatusBar/Model/AppModel.swift
+++ b/PrusaStatusBar/Model/AppModel.swift
@@ -117,10 +117,15 @@ public final class AppModel {
     /// also fires on resume from pause.
     public var printingBurstToken: Int = 0
 
-    /// True only while the dropdown popover is on screen. Drives conditional
-    /// mounting of resource-heavy views (camera tile + go2rtc helper) so the
-    /// app does not stream RTSP while the menu is closed.
+    /// True only while the dropdown popover is on screen OR the detached status
+    /// window is open. Drives conditional mounting of resource-heavy views
+    /// (camera tile + go2rtc helper) so the app does not stream RTSP while
+    /// the menu is closed.
     public var popoverVisible: Bool = false
+
+    /// True while the detached status window is open. `MenuBarController` uses
+    /// this to route left-clicks to the window instead of toggling the popover.
+    public var detachedWindowVisible: Bool = false
 
     /// Last rendered camera tile height per kind, captured the first time
     /// each tile draws a real frame in the current online session. Drives

--- a/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "Nastavení";
 "footer.quit"                             = "Ukončit";
 "footer.update.available"                 = "Nová verze k dispozici";
+"footer.detach"                           = "Oddělit do okna";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "Otevřít PrusaLink v prohlížeči";

--- a/PrusaStatusBar/Resources/de.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/de.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "Einstellungen";
 "footer.quit"                             = "Beenden";
 "footer.update.available"                 = "Neue Version verfügbar";
+"footer.detach"                           = "Als Fenster ablösen";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "PrusaLink im Browser öffnen";

--- a/PrusaStatusBar/Resources/en.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/en.lproj/Localizable.strings
@@ -225,6 +225,7 @@
 "footer.preferences"                      = "Preferences";
 "footer.quit"                             = "Quit";
 "footer.update.available"                 = "New version available";
+"footer.detach"                           = "Detach to window";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "Open PrusaLink in your browser";

--- a/PrusaStatusBar/Resources/es.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/es.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "Ajustes";
 "footer.quit"                             = "Salir";
 "footer.update.available"                 = "Nueva versión disponible";
+"footer.detach"                           = "Separar a ventana";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "Abrir PrusaLink en el navegador";

--- a/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "Préférences";
 "footer.quit"                             = "Quitter";
 "footer.update.available"                 = "Nouvelle version disponible";
+"footer.detach"                           = "Détacher vers une fenêtre";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "Ouvrir PrusaLink dans le navigateur";

--- a/PrusaStatusBar/Resources/it.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/it.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "Impostazioni";
 "footer.quit"                             = "Esci";
 "footer.update.available"                 = "Nuova versione disponibile";
+"footer.detach"                           = "Separa in finestra";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "Apri PrusaLink nel browser";

--- a/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "環境設定";
 "footer.quit"                             = "終了";
 "footer.update.available"                 = "新しいバージョンが利用可能";
+"footer.detach"                           = "ウィンドウに切り離す";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "ブラウザで PrusaLink を開く";

--- a/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "Ustawienia";
 "footer.quit"                             = "Zakończ";
 "footer.update.available"                 = "Dostępna nowa wersja";
+"footer.detach"                           = "Odepnij do okna";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "Otwórz PrusaLink w przeglądarce";

--- a/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "Ajustes";
 "footer.quit"                             = "Sair";
 "footer.update.available"                 = "Nova versão disponível";
+"footer.detach"                           = "Separar para janela";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "Abrir PrusaLink no navegador";

--- a/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -217,6 +217,7 @@
 "footer.preferences"                      = "偏好设置";
 "footer.quit"                             = "退出";
 "footer.update.available"                 = "有新版本可用";
+"footer.detach"                           = "分离到窗口";
 
 // Links row
 "links.prusalink.tooltip_enabled"         = "在浏览器中打开 PrusaLink";

--- a/PrusaStatusBar/UI/CameraStreamKeepalive.swift
+++ b/PrusaStatusBar/UI/CameraStreamKeepalive.swift
@@ -22,6 +22,7 @@ final class CameraStreamKeepalive {
 
     private var openPopups: Set<CameraTileKind> = []
     private var popoverVisible: Bool = false
+    private var detachedWindowOpen: Bool = false
 
     init(stopGoRTC: @escaping @MainActor () -> Void) {
         self.stopGoRTC = stopGoRTC
@@ -41,7 +42,7 @@ final class CameraStreamKeepalive {
         // The last popup just closed and the popover is also closed, so
         // nothing in the app needs the helper. Mirror the original
         // popover-close teardown.
-        if openPopups.isEmpty, !popoverVisible {
+        if openPopups.isEmpty, !popoverVisible, !detachedWindowOpen {
             stopGoRTC()
         }
     }
@@ -51,10 +52,23 @@ final class CameraStreamKeepalive {
     }
 
     /// Called from `MenuBarPopoverDelegate.popoverDidClose`. Tears down
-    /// go2rtc only when no popup is keeping it alive.
+    /// go2rtc only when no popup or detached window is keeping it alive.
     func popoverDidClose() {
         popoverVisible = false
-        if openPopups.isEmpty {
+        if openPopups.isEmpty, !detachedWindowOpen {
+            stopGoRTC()
+        }
+    }
+
+    /// Call BEFORE closing the popover when detaching to a window so the
+    /// popover-close path does not tear down go2rtc mid-transition.
+    func detachedWindowDidOpen() {
+        detachedWindowOpen = true
+    }
+
+    func detachedWindowDidClose() {
+        detachedWindowOpen = false
+        if openPopups.isEmpty, !popoverVisible {
             stopGoRTC()
         }
     }

--- a/PrusaStatusBar/UI/Components/CameraPlayer.swift
+++ b/PrusaStatusBar/UI/Components/CameraPlayer.swift
@@ -15,21 +15,34 @@
     struct CameraPlayerView: NSViewRepresentable {
         let url: URL
         let onFailureExhausted: (() -> Void)?
+        let onReady: (() -> Void)?
+        let onPresentationSize: ((CGSize) -> Void)?
 
-        init(url: URL, onFailureExhausted: (() -> Void)? = nil) {
+        init(
+            url: URL,
+            onFailureExhausted: (() -> Void)? = nil,
+            onReady: (() -> Void)? = nil,
+            onPresentationSize: ((CGSize) -> Void)? = nil
+        ) {
             self.url = url
             self.onFailureExhausted = onFailureExhausted
+            self.onReady = onReady
+            self.onPresentationSize = onPresentationSize
         }
 
         func makeNSView(context _: Context) -> PlayerNSView {
             let view = PlayerNSView()
             view.failureExhaustedHandler = onFailureExhausted
+            view.readyHandler = onReady
+            view.presentationSizeHandler = onPresentationSize
             view.load(url: url)
             return view
         }
 
         func updateNSView(_ nsView: PlayerNSView, context _: Context) {
             nsView.failureExhaustedHandler = onFailureExhausted
+            nsView.readyHandler = onReady
+            nsView.presentationSizeHandler = onPresentationSize
             nsView.load(url: url)
         }
 
@@ -43,12 +56,26 @@
         private var player: AVPlayer?
         private var loadedURL: URL?
         private var statusObservation: NSKeyValueObservation?
+        private var presentationSizeObservation: NSKeyValueObservation?
+        private var lastReportedPresentationSize: CGSize = .zero
         private var retryAttempt: Int = 0
         private var pendingRetry: Task<Void, Never>?
 
         /// Invoked once the retry budget exhausts without `.readyToPlay`.
         /// Used by `GenericCameraTile` to fall back to still-image polling.
         var failureExhaustedHandler: (() -> Void)?
+
+        /// Invoked the first time the underlying `AVPlayerItem` flips to
+        /// `.readyToPlay`. Tiles use it to hide their loading spinner and
+        /// expand to the real video height. Kept sticky on the caller side
+        /// so transient stalls do not flap the spinner back on.
+        var readyHandler: (() -> Void)?
+
+        /// Invoked when the underlying `AVPlayerItem` reports a non-zero
+        /// `presentationSize`, and again if that size changes. Tiles use it
+        /// to lock their aspect ratio to the actual video so AVPlayerLayer
+        /// does not add letterbox/pillarbox bars.
+        var presentationSizeHandler: ((CGSize) -> Void)?
 
         /// go2rtc is started on demand in the same runloop tick the popover
         /// opens, but its HTTP API takes a few hundred ms to a couple of
@@ -98,17 +125,24 @@
             pendingRetry = nil
             statusObservation?.invalidate()
             statusObservation = nil
+            presentationSizeObservation?.invalidate()
+            presentationSizeObservation = nil
+            lastReportedPresentationSize = .zero
             player?.pause()
             playerLayer.player = nil
             player = nil
             loadedURL = nil
             retryAttempt = 0
             failureExhaustedHandler = nil
+            readyHandler = nil
+            presentationSizeHandler = nil
         }
 
         private func installPlayer(url: URL) {
             statusObservation?.invalidate()
             statusObservation = nil
+            presentationSizeObservation?.invalidate()
+            presentationSizeObservation = nil
             let item = AVPlayerItem(url: url)
             let player = AVPlayer(playerItem: item)
             player.isMuted = true
@@ -127,7 +161,22 @@
                 }
             }
 
+            let opts: NSKeyValueObservingOptions = [.new, .initial]
+            presentationSizeObservation = item.observe(\.presentationSize, options: opts) { [weak self] item, _ in
+                let size = item.presentationSize
+                Task { @MainActor in
+                    self?.handle(presentationSize: size)
+                }
+            }
+
             player.play()
+        }
+
+        private func handle(presentationSize: CGSize) {
+            guard presentationSize.width > 0, presentationSize.height > 0 else { return }
+            if presentationSize == lastReportedPresentationSize { return }
+            lastReportedPresentationSize = presentationSize
+            presentationSizeHandler?(presentationSize)
         }
 
         private func handle(itemStatus: AVPlayerItem.Status, errorMessage _: String?) {
@@ -136,6 +185,7 @@
                 retryAttempt = 0
                 pendingRetry?.cancel()
                 pendingRetry = nil
+                readyHandler?()
             case .failed:
                 scheduleRetry()
             case .unknown:

--- a/PrusaStatusBar/UI/Components/CameraTile.swift
+++ b/PrusaStatusBar/UI/Components/CameraTile.swift
@@ -18,12 +18,30 @@ struct CameraTile: View {
 
     private let kind: CameraTileKind = .buddy
 
+    /// Sticky readiness flag. Flips true once the player reports the first
+    /// `.readyToPlay` and stays true for the lifetime of this view so the
+    /// spinner does not flap back on during transient stalls. A new RTSP
+    /// URL resets it via the `.id(urlString)` view-identity bump.
+    @State private var isReady: Bool = false
+    /// Native video aspect (width / height) reported by the player. Nil
+    /// until the first frame is decoded. Used to size the tile to the
+    /// actual video so AVPlayerLayer does not add black bars.
+    @State private var videoAspect: CGFloat?
+
     var body: some View {
         ZStack {
             Color.black
             content
+            if showsLoadingSpinner {
+                loadingOverlay
+            }
         }
-        .modifier(CameraTileFrame(model: model, kind: kind))
+        .modifier(CameraTileFrame(
+            model: model,
+            kind: kind,
+            isReady: !showsLoadingSpinner,
+            videoAspect: videoAspect
+        ))
         .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
@@ -36,6 +54,26 @@ struct CameraTile: View {
             }
         }
         .id(urlString)
+    }
+
+    private var loadingOverlay: some View {
+        ProgressView()
+            .controlSize(.small)
+            .progressViewStyle(.circular)
+            .tint(.white)
+            .allowsHitTesting(false)
+    }
+
+    /// Only show the spinner while we are actively waiting for an HLS
+    /// stream. In prototype mode and in the "invalid URL" branch, the
+    /// content view already conveys state, so a spinner on top would be
+    /// noise.
+    private var showsLoadingSpinner: Bool {
+        #if PROTOTYPE_MODE
+            return false
+        #else
+            return resolveHLSURL() != nil && !isReady
+        #endif
     }
 
     @ViewBuilder
@@ -51,7 +89,14 @@ struct CameraTile: View {
             }
         #else
             if let hlsURL = resolveHLSURL() {
-                CameraPlayerView(url: hlsURL)
+                CameraPlayerView(
+                    url: hlsURL,
+                    onReady: { isReady = true },
+                    onPresentationSize: { size in
+                        guard size.height > 0 else { return }
+                        videoAspect = size.width / size.height
+                    }
+                )
             } else {
                 Text(L10n.t("error.rtsp.invalid"))
                     .font(.prusaCaption)
@@ -98,9 +143,26 @@ let cameraTilePlaceholderMinHeight: CGFloat = 180
 struct CameraTileFrame: ViewModifier {
     let model: AppModel
     let kind: CameraTileKind
+    /// When `false`, ignore any cached video height and fall back to the
+    /// loading-state placeholder. Avoids a giant black rectangle while the
+    /// player is still warming up after the cache was populated by an
+    /// earlier successful render.
+    var isReady: Bool = true
+    /// Native video aspect (width / height) reported by AVPlayerItem
+    /// once decoding starts. When set, the tile is sized to that aspect
+    /// so AVPlayerLayer's `.resizeAspect` fills exactly with no
+    /// letterbox/pillarbox bars. Falls back to cached or placeholder
+    /// height when nil.
+    var videoAspect: CGFloat?
 
     func body(content: Content) -> some View {
-        if let cached = model.cameraTileHeights[kind] {
+        if !isReady {
+            content.frame(maxWidth: .infinity, minHeight: cameraTilePlaceholderMinHeight)
+        } else if let aspect = videoAspect, aspect > 0 {
+            content
+                .frame(maxWidth: .infinity)
+                .aspectRatio(aspect, contentMode: .fit)
+        } else if let cached = model.cameraTileHeights[kind] {
             content.frame(maxWidth: .infinity, minHeight: cached, maxHeight: cached)
         } else {
             content.frame(maxWidth: .infinity, minHeight: cameraTilePlaceholderMinHeight)

--- a/PrusaStatusBar/UI/Components/FooterBar.swift
+++ b/PrusaStatusBar/UI/Components/FooterBar.swift
@@ -1,18 +1,19 @@
 import SwiftUI
 
-/// Slim bottom row with two icon-only buttons: gear (Preferences, ⌘,) on
-/// the leading edge and power (Quit, ⌘Q) on the trailing edge. When
-/// `availableUpdate` is non-nil, a centered "New version available"
-/// button in `Color("BrandGreen")` sits between them and opens the
-/// GitHub release page on click. No surface fill or border, the chrome
-/// blends into the popover background. Refresh lives in `HeroHeader`,
-/// next to the "Updated Xs ago..." line, per
-/// `openspec/specs/menu-bar-ui/spec.md`.
+/// Slim bottom row with icon-only buttons: gear (Preferences, ⌘,) on the
+/// leading edge followed immediately by the optional detach button, then
+/// a centered "New version available" callout when an update is available,
+/// and power (Quit, ⌘Q) on the trailing edge. No surface fill or border --
+/// the chrome blends into the popover background. Refresh lives in
+/// `HeroHeader`, per `openspec/specs/menu-bar-ui/spec.md`.
 struct FooterBar: View {
     let onPreferences: () -> Void
     let onQuit: () -> Void
     var availableUpdate: GitHubRelease?
     var onOpenRelease: () -> Void = {}
+    /// When non-nil, shows a "Detach to window" button immediately after the
+    /// Preferences button. Pass `nil` inside the detached window itself.
+    var onDetach: (() -> Void)?
 
     var body: some View {
         HStack(spacing: 0) {
@@ -23,6 +24,15 @@ struct FooterBar: View {
                 action: onPreferences
             )
             .keyboardShortcut(",", modifiers: [.command])
+
+            if let onDetach {
+                FooterIconButton(
+                    symbol: "pip.enter",
+                    title: L10n.t("footer.detach"),
+                    shortcutHint: nil,
+                    action: onDetach
+                )
+            }
 
             Spacer(minLength: 0)
 
@@ -45,12 +55,19 @@ struct FooterBar: View {
 private struct FooterIconButton: View {
     let symbol: String
     let title: String
-    let shortcutHint: String
+    var shortcutHint: String?
     let action: () -> Void
 
     @State private var isHovering = false
     @Environment(\.brandAccent) private var accent
     @Environment(\.brandCustomHex) private var customHex
+
+    private var helpText: String {
+        if let shortcutHint, !shortcutHint.isEmpty {
+            return "\(title) (\(shortcutHint))"
+        }
+        return title
+    }
 
     var body: some View {
         Button(action: action) {
@@ -62,8 +79,8 @@ private struct FooterIconButton: View {
         }
         .buttonStyle(.plain)
         .foregroundStyle(isHovering ? Theme.Palette.brand(accent, customHex: customHex) : Theme.Palette.textSecondary)
-        .help("\(title) (\(shortcutHint))")
-        .accessibilityLabel(Text("\(title) (\(shortcutHint))"))
+        .help(helpText)
+        .accessibilityLabel(Text(helpText))
         .onHover { isHovering = $0 }
     }
 }

--- a/PrusaStatusBar/UI/Components/GenericCameraTile.swift
+++ b/PrusaStatusBar/UI/Components/GenericCameraTile.swift
@@ -15,13 +15,29 @@ struct GenericCameraTile: View {
     private let kind: CameraTileKind = .generic
 
     @State private var fallbackToStill: Bool = false
+    /// Sticky readiness flag for the stream branch. Mirrors `CameraTile`:
+    /// flips true on first `.readyToPlay`, reset when the active source
+    /// changes (via `.id(tileIdentity)`).
+    @State private var isReady: Bool = false
+    /// Native video aspect (width / height) reported by the player. Nil
+    /// until the first frame decodes. Used to size the tile to the actual
+    /// video and avoid AVPlayerLayer black bars.
+    @State private var videoAspect: CGFloat?
 
     var body: some View {
         ZStack {
             Color.black
             content
+            if showsLoadingSpinner {
+                loadingOverlay
+            }
         }
-        .modifier(CameraTileFrame(model: model, kind: kind))
+        .modifier(CameraTileFrame(
+            model: model,
+            kind: kind,
+            isReady: !showsLoadingSpinner,
+            videoAspect: videoAspect
+        ))
         .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Theme.Radius.card, style: .continuous)
@@ -36,9 +52,31 @@ struct GenericCameraTile: View {
         .id(tileIdentity)
         .onChange(of: tileIdentity) { _, _ in
             // Reset fallback whenever the active source changes; the new
-            // stream gets a fresh retry budget.
+            // stream gets a fresh retry budget. Same for readiness and
+            // video aspect, the new stream has to prove itself again.
             fallbackToStill = false
+            isReady = false
+            videoAspect = nil
         }
+    }
+
+    private var loadingOverlay: some View {
+        ProgressView()
+            .controlSize(.small)
+            .progressViewStyle(.circular)
+            .tint(.white)
+            .allowsHitTesting(false)
+    }
+
+    /// Only show the spinner while the stream branch is warming up. The
+    /// still-image branch has its own loading affordance in
+    /// `StillImagePollerView`.
+    private var showsLoadingSpinner: Bool {
+        #if PROTOTYPE_MODE
+            return false
+        #else
+            return shouldRenderStream && resolveStreamHLSURL() != nil && !isReady
+        #endif
     }
 
     @ViewBuilder
@@ -86,7 +124,12 @@ struct GenericCameraTile: View {
             if shouldRenderStream, let hlsURL = resolveStreamHLSURL() {
                 CameraPlayerView(
                     url: hlsURL,
-                    onFailureExhausted: handleStreamFailure
+                    onFailureExhausted: handleStreamFailure,
+                    onReady: { isReady = true },
+                    onPresentationSize: { size in
+                        guard size.height > 0 else { return }
+                        videoAspect = size.width / size.height
+                    }
                 )
             } else if let stillURL = config.resolvedStillImageURL() {
                 StillImagePollerView(url: stillURL, config: config)

--- a/PrusaStatusBar/UI/DetachedStatusWindowController.swift
+++ b/PrusaStatusBar/UI/DetachedStatusWindowController.swift
@@ -1,0 +1,112 @@
+import AppKit
+import SwiftUI
+
+/// Owns the lifecycle of the detached status `NSWindow` that the user
+/// can open via the "Detach" footer button. The window hosts the same
+/// `DropdownView` content as the popover but is NOT transient -- it
+/// stays on screen when the user clicks elsewhere.
+///
+/// Mirrors `CameraQuickLookWindowController` in shape: `present(view:)`
+/// creates a new window on first call or brings the existing one to the
+/// front. The frame is NOT autosaved: every detach centers on the active
+/// screen and sizes height to current content via a few timed
+/// `sizeThatFits` polls (cheap, one-way, no layout loop).
+@MainActor
+final class DetachedStatusWindowController: NSObject, NSWindowDelegate {
+    private let onShow: () -> Void
+    private let onClose: () -> Void
+    private(set) var window: NSWindow?
+    private var host: NSHostingController<DropdownView>?
+    private var sizingTask: Task<Void, Never>?
+
+    init(onShow: @escaping () -> Void, onClose: @escaping () -> Void) {
+        self.onShow = onShow
+        self.onClose = onClose
+        super.init()
+    }
+
+    /// Present the detached window. Creates a new window if none exists;
+    /// brings the existing one to front otherwise (updating its root view
+    /// to reflect the latest closure bindings).
+    func present(view: DropdownView) {
+        if let window {
+            host?.rootView = view
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+
+        let hosting = NSHostingController(rootView: view)
+        // Do NOT set hosting.sizingOptions = [.preferredContentSize]:
+        // SwiftUI animations and async state changes can re-trigger the
+        // preferred size update, which AppKit then re-applies to the window,
+        // which re-triggers layout -- a loop that crashes. We poll size
+        // manually instead (see fitWindowToContent), which is one-way.
+        let newWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 400),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        newWindow.contentViewController = hosting
+        newWindow.contentMinSize = NSSize(width: 360, height: 200)
+        newWindow.level = .floating
+        newWindow.isReleasedWhenClosed = false
+        newWindow.collectionBehavior = [.fullScreenAuxiliary, .moveToActiveSpace]
+        newWindow.delegate = self
+        newWindow.center()
+
+        window = newWindow
+        host = hosting
+        onShow()
+        newWindow.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        fitWindowToContent(hosting: hosting)
+    }
+
+    func bringToFront() {
+        guard let window else { return }
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard (notification.object as? NSWindow) === window else { return }
+        sizingTask?.cancel()
+        sizingTask = nil
+        window = nil
+        host = nil
+        onClose()
+    }
+
+    /// Poll the hosting controller's fitted size at a few timed offsets and
+    /// resize the window to match. Multiple passes catch late-mounting
+    /// content (camera tiles, status sections that depend on async data).
+    /// One-way: we read `sizeThatFits`, we write the window frame -- no KVO,
+    /// no `sizingOptions` binding, so no layout loop.
+    private func fitWindowToContent(hosting: NSHostingController<DropdownView>) {
+        sizingTask?.cancel()
+        sizingTask = Task { @MainActor [weak self] in
+            let delaysMs: [UInt64] = [0, 80, 250, 600]
+            for delay in delaysMs {
+                if delay > 0 {
+                    try? await Task.sleep(nanoseconds: delay * 1_000_000)
+                }
+                if Task.isCancelled { return }
+                guard let self, let w = window, host === hosting else { return }
+                let fitted = hosting.sizeThatFits(in: NSSize(width: 360, height: 10000))
+                guard fitted.height > 50 else { continue }
+                let maxH = (w.screen?.visibleFrame.height ?? NSScreen.main?.visibleFrame.height ?? 900) - 100
+                let height = min(fitted.height, maxH)
+                if abs(w.frame.height - height) > 0.5 {
+                    var frame = w.frame
+                    frame.origin.y += frame.height - height
+                    frame.size.height = height
+                    w.setFrame(frame, display: true, animate: false)
+                }
+            }
+            self?.sizingTask = nil
+        }
+    }
+}

--- a/PrusaStatusBar/UI/DropdownView.swift
+++ b/PrusaStatusBar/UI/DropdownView.swift
@@ -33,6 +33,11 @@ struct DropdownView: View {
     /// previews and tests free from window-controller plumbing.
     var onZoomCamera: (CameraTileKind, CameraQuickLookSource) -> Void = { _, _ in }
 
+    /// Detaches the dropdown into a persistent floating window. `nil`
+    /// hides the button (used inside the detached window to prevent
+    /// circular detach).
+    var onDetach: (() -> Void)?
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State var customActionFeedback: [CustomActionSlot: CustomActionFeedback] = [:]
 
@@ -59,27 +64,39 @@ struct DropdownView: View {
                 onRunRight: { runCustomAction(.headerRight) }
             )
 
-            // ViewThatFits picks the non-scrolling layout when the middle
-            // region fits within the bound below; otherwise it falls back to a
-            // ScrollView so the user can reach every section without losing
-            // sight of the pinned FooterBar (Preferences / Quit).
-            ViewThatFits(in: .vertical) {
+            // Detached window: render middleStack with its natural intrinsic
+            // size so NSHostingController's preferredContentSize reflects the
+            // real content height. The controller uses that to auto-fit the
+            // window. If the user manually shrinks the window, content clips
+            // (acceptable trade-off vs. an always-empty scroll area).
+            // Popover: ViewThatFits prefers no scroll; falls back to ScrollView
+            // with permanent indicator when content overflows the fixed popover
+            // height.
+            if model.detachedWindowVisible {
                 middleStack
-                ScrollView(.vertical, showsIndicators: true) {
+            } else {
+                ViewThatFits(in: .vertical) {
                     middleStack
+                    ScrollView(.vertical, showsIndicators: true) {
+                        middleStack
+                    }
+                    .scrollBounceBehavior(.basedOnSize)
                 }
-                .scrollBounceBehavior(.basedOnSize)
             }
 
             FooterBar(onPreferences: onPreferences, onQuit: onQuit,
-                      availableUpdate: model.availableUpdate, onOpenRelease: onOpenRelease)
+                      availableUpdate: model.availableUpdate, onOpenRelease: onOpenRelease,
+                      onDetach: onDetach)
                 .padding(.top, -Theme.Spacing.xxs - 2)
         }
         .padding(.horizontal, Theme.Layout.popoverPadding)
         .padding(.top, Theme.Layout.popoverPadding)
         .padding(.bottom, Theme.Layout.popoverFooterBottomPadding)
         .frame(width: Theme.Layout.popoverWidth, alignment: .topLeading)
-        .frame(maxHeight: maxPopoverHeight, alignment: .topLeading)
+        .frame(
+            maxHeight: model.detachedWindowVisible ? nil : maxPopoverHeight,
+            alignment: .topLeading
+        )
         .background(.regularMaterial)
         .environment(\.brandAccent, model.accent)
         .environment(\.brandCustomHex, model.customAccentHex)
@@ -143,11 +160,6 @@ struct DropdownView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var maxPopoverHeight: CGFloat {
-        let screenHeight = NSScreen.main?.visibleFrame.height ?? 900
-        return max(200, screenHeight - Theme.Layout.popoverScreenMargin)
-    }
-
     // MARK: - Variant routing
 
     private enum Presentation: Equatable {
@@ -159,21 +171,6 @@ struct DropdownView: View {
 
     private enum PresentationKind: Equatable {
         case unconfigured, disconnected, loading, content
-    }
-
-    private var presentationKind: PresentationKind {
-        switch presentation {
-        case .unconfigured: .unconfigured
-        case .disconnected: .disconnected
-        case .loading: .loading
-        case .content: .content
-        }
-    }
-
-    private var shouldRenderGenericCameraTile: Bool {
-        model.popoverVisible
-            && model.genericCameraConfig.enabled
-            && model.genericCameraConfig.hasUsableSource
     }
 
     private var presentation: Presentation {
@@ -413,7 +410,7 @@ extension DropdownView {
             // `CameraPlayerView.dismantleNSView` -> AVPlayer pause/clear.
             // The popover delegate additionally stops go2rtc, so neither
             // CPU nor camera bandwidth is used while the menu is closed.
-            if model.popoverVisible, model.buddyCameraEnabled, let rtsp = nonEmpty(model.rtspURL) {
+            if dropdownVisible, model.buddyCameraEnabled, let rtsp = nonEmpty(model.rtspURL) {
                 CameraTile(urlString: rtsp, model: model, onZoom: { onZoomCamera(.buddy, $0) })
             }
 
@@ -440,6 +437,34 @@ extension DropdownView {
 
             LiveMetricsCard(rows: extraRows(for: status))
         }
+    }
+}
+
+private extension DropdownView {
+    /// True whenever the dropdown content is on screen -- either inside the
+    /// transient popover or inside the detached floating window.
+    var dropdownVisible: Bool {
+        model.popoverVisible || model.detachedWindowVisible
+    }
+
+    var maxPopoverHeight: CGFloat {
+        let screenHeight = NSScreen.main?.visibleFrame.height ?? 900
+        return max(200, screenHeight - Theme.Layout.popoverScreenMargin)
+    }
+
+    private var presentationKind: PresentationKind {
+        switch presentation {
+        case .unconfigured: .unconfigured
+        case .disconnected: .disconnected
+        case .loading: .loading
+        case .content: .content
+        }
+    }
+
+    var shouldRenderGenericCameraTile: Bool {
+        dropdownVisible
+            && model.genericCameraConfig.enabled
+            && model.genericCameraConfig.hasUsableSource
     }
 }
 

--- a/PrusaStatusBar/UI/MenuBarController+Popover.swift
+++ b/PrusaStatusBar/UI/MenuBarController+Popover.swift
@@ -2,15 +2,11 @@ import AppKit
 import SwiftUI
 
 extension MenuBarController {
-    /// Builds the popover's `NSHostingController<DropdownView>` once at
-    /// init time. The hosting controller stays mounted for the app's
-    /// lifetime so scroll position and other SwiftUI `@State` survive
-    /// close/reopen. CPU drain from periodic `TimelineView` / `Timer`
-    /// updates inside the dropdown is gated on `model.popoverVisible`
-    /// at the leaf views (HeroHeader, ProgressBarPremium, StatusPill)
-    /// instead of by tearing down the tree.
-    func installPopoverContent() {
-        let view = DropdownView(
+    /// Builds a fully wired `DropdownView`. Pass `onDetach` to show the
+    /// "Detach" footer button (popover context); pass `nil` to hide it
+    /// (detached window context, where nesting would be circular).
+    func makeDropdownView(onDetach: (() -> Void)? = nil) -> DropdownView {
+        var view = DropdownView(
             model: model,
             onRefresh: { [weak self] in self?.coordinator.refreshNow() },
             onPreferences: { [weak self] in self?.openPreferences() },
@@ -20,16 +16,29 @@ extension MenuBarController {
             onOpenPrusaConnect: { [weak self] in self?.openPrusaConnect() },
             onResume: { [weak self] in self?.coordinator.resumeCurrentJob() },
             onPause: { [weak self] in self?.coordinator.pauseCurrentJob() },
-            onStop: { [weak self] in self?.coordinator.stopCurrentJob() },
-            onOpenRelease: { [weak self] in self?.openLatestRelease() },
-            onRunCustomAction: { [weak self] slot in
-                guard let self else { return .failure(.slotMissingConfig) }
-                return await runCustomAction(slot)
-            },
-            onZoomCamera: { [weak self] kind, source in
-                self?.cameraQuickLook.open(kind: kind, source: source)
-            }
+            onStop: { [weak self] in self?.coordinator.stopCurrentJob() }
         )
+        view.onOpenRelease = { [weak self] in self?.openLatestRelease() }
+        view.onRunCustomAction = { [weak self] slot in
+            guard let self else { return .failure(.slotMissingConfig) }
+            return await runCustomAction(slot)
+        }
+        view.onZoomCamera = { [weak self] kind, source in
+            self?.cameraQuickLook.open(kind: kind, source: source)
+        }
+        view.onDetach = onDetach
+        return view
+    }
+
+    /// Builds the popover's `NSHostingController<DropdownView>` once at
+    /// init time. The hosting controller stays mounted for the app's
+    /// lifetime so scroll position and other SwiftUI `@State` survive
+    /// close/reopen. CPU drain from periodic `TimelineView` / `Timer`
+    /// updates inside the dropdown is gated on `model.popoverVisible`
+    /// at the leaf views (HeroHeader, ProgressBarPremium, StatusPill)
+    /// instead of by tearing down the tree.
+    func installPopoverContent() {
+        let view = makeDropdownView(onDetach: { [weak self] in self?.detach() })
         let host = NSHostingController(rootView: view)
         // Track SwiftUI body's fitting size so the popover both grows AND
         // shrinks when content size changes (e.g. ActionsSection collapse).

--- a/PrusaStatusBar/UI/MenuBarController.swift
+++ b/PrusaStatusBar/UI/MenuBarController.swift
@@ -23,6 +23,10 @@ public final class MenuBarController {
     /// defers go2rtc teardown while a popup is open.
     let cameraQuickLook: CameraQuickLookCoordinator
 
+    /// Owns the detached status window that the user can open via the
+    /// "Detach" footer button. Nil until first detach.
+    let detachedWindowController: DetachedStatusWindowController
+
     /// Drives the bounded 2-cycle "printing" burst on the menu bar. Owned
     /// by the controller so it can be cancelled when the state leaves
     /// `.printing` mid-burst.
@@ -79,6 +83,21 @@ public final class MenuBarController {
             onClose: { coordinator.keepalive.popoverDidClose() }
         )
         popover.delegate = popoverDelegate
+
+        detachedWindowController = DetachedStatusWindowController(
+            onShow: { [weak model] in
+                guard let model else { return }
+                // Unconditionally assert visible so cameras mount even if the
+                // async popoverDidClose Task ran before present() returned.
+                model.popoverShowToken &+= 1
+                model.popoverVisible = true
+            },
+            onClose: { [weak model, weak coordinator] in
+                model?.popoverVisible = false
+                model?.detachedWindowVisible = false
+                coordinator?.keepalive.detachedWindowDidClose()
+            }
+        )
 
         configureButton()
         scheduleRefresh()
@@ -281,6 +300,10 @@ public final class MenuBarController {
             openPreferences()
             return
         }
+        if model.detachedWindowVisible {
+            detachedWindowController.bringToFront()
+            return
+        }
         togglePopover(relativeTo: button)
     }
 
@@ -292,6 +315,18 @@ public final class MenuBarController {
             popover.show(relativeTo: view.bounds, of: view, preferredEdge: .minY)
             popover.contentViewController?.view.window?.makeKey()
         }
+    }
+
+    /// Closes the transient popover and opens the content in a persistent
+    /// floating `NSWindow`. Registers with the keepalive BEFORE closing
+    /// the popover so the popover-close path does not tear down go2rtc.
+    func detach() {
+        cameraQuickLook.keepalive.detachedWindowDidOpen()
+        // Set detachedWindowVisible BEFORE performClose so the async
+        // handlePopoverDidClose Task sees it and skips clearing popoverVisible.
+        model.detachedWindowVisible = true
+        popover.performClose(nil)
+        detachedWindowController.present(view: makeDropdownView(onDetach: nil))
     }
 }
 
@@ -343,7 +378,12 @@ final class MenuBarPopoverDelegate: NSObject, NSPopoverDelegate {
     /// injected `onClose` after flipping the visibility flag, so tests can
     /// observe the helper-stop call.
     func handlePopoverDidClose() {
-        model.popoverVisible = false
+        // When detaching, the window is already open and takes over the
+        // "visible" contract. Clearing popoverVisible would unmount camera
+        // tiles in the detached window and could crash AVPlayer cleanup.
+        if !model.detachedWindowVisible {
+            model.popoverVisible = false
+        }
         // SwiftUI dismantling the CameraTile pauses AVPlayer, but the
         // helper subprocess keeps the upstream RTSP session warm unless
         // we explicitly stop it. Doing it here means zero camera-side


### PR DESCRIPTION
<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

Add sidebar detachable window from menubar as suggested #5 .

## Screenshots / GIFs

<img width="716" height="1960" alt="screenshot_2026-05-16_07 18 55@2x" src="https://github.com/user-attachments/assets/f02c2111-4ee8-42d5-99a6-88fe09da2d93" />

<img width="708" height="1870" alt="screenshot_2026-05-16_07 26 47@2x" src="https://github.com/user-attachments/assets/a94afac1-c63f-4bf8-a939-e4a61b48db39" />

## Checklist

- [X] Tests added or updated (Swift Testing).
- [X] `just check` passes locally.
- [X] `just test` passes locally.
- [X] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [X] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Add support for detaching the menu bar dropdown into a persistent floating status window while reusing the existing dropdown content.

New Features:
- Introduce a detachable floating status window that hosts the same content as the menu bar dropdown.
- Add an optional detach button to the footer bar that appears when detaching is available.

Bug Fixes:
- Ensure camera playback and helper teardown behave correctly when transitioning between the popover and detached window.

Enhancements:
- Unify visibility handling so camera tiles and other resource-heavy views stay mounted when either the popover or detached window is visible.
- Refine dropdown scrolling behavior to better match popover constraints versus the resizable detached window.
- Improve camera stream keepalive logic to account for the detached window and avoid unnecessary teardown or crashes.