### PR TITLE
feat: add temperature orientation arrows (heat/cooldown)

### DIFF
--- a/PrusaStatusBar.xcodeproj/project.pbxproj
+++ b/PrusaStatusBar.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		7FE1BF46F5F71E58DEBAD239 /* CameraPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99897CAE7E41EB3A3140FC54 /* CameraPlayer.swift */; };
 		81047AA9419EB3850EC11E26 /* ActionsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0AC5858D7126443E050D4E /* ActionsSectionTests.swift */; };
 		82256F6D16AABFEBF955E7EA /* CameraTileSizeCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC65D4922A9954AE4AB8AFD0 /* CameraTileSizeCacheTests.swift */; };
+		82BE0F10C9B8A185876900FF /* TempCardArrowStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F6F8110A622470926C247DE /* TempCardArrowStateTests.swift */; };
 		8370958330130DF9ADBB32B3 /* ApiKeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D262344DCDDEA3A7101F41D /* ApiKeyStoreTests.swift */; };
 		846EDD75B6155A08D3B000B7 /* RTSPProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B62CEA9034D1A5AAF8624E /* RTSPProbeTests.swift */; };
 		86B855EEA0F810E156D4B2B6 /* DropdownView+CustomActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5E3A827E5B85503CE799041 /* DropdownView+CustomActions.swift */; };
@@ -288,6 +289,7 @@
 		7D262344DCDDEA3A7101F41D /* ApiKeyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiKeyStoreTests.swift; sourceTree = "<group>"; };
 		7D3EDC5E5EBFA483A7875E77 /* RefreshIntervalEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshIntervalEditor.swift; sourceTree = "<group>"; };
 		7D413B5006C1449975021ED6 /* GeneralTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralTab.swift; sourceTree = "<group>"; };
+		7F6F8110A622470926C247DE /* TempCardArrowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempCardArrowStateTests.swift; sourceTree = "<group>"; };
 		80E437CA0200D1D803623DD6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		816C9EDB1DDC6DCFD7C7E377 /* Fonts */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Fonts; path = PrusaStatusBar/Resources/Fonts; sourceTree = SOURCE_ROOT; };
 		83451F1C94F8CD12C7449A73 /* CustomActionSlotBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionSlotBody.swift; sourceTree = "<group>"; };
@@ -606,6 +608,7 @@
 				690CE17E3BC554F68FCD1EC3 /* StatusPresenterTests.swift */,
 				E012958219D387974AE1ED2E /* StubLoginItemServiceTests.swift */,
 				1DF85DFCC98EB910E6288132 /* StubNotificationServiceTests.swift */,
+				7F6F8110A622470926C247DE /* TempCardArrowStateTests.swift */,
 				BEEADA2D885A1C93185925EA /* ThemeAccentTests.swift */,
 				B068DF8D99041051EFC7FA85 /* UpdateCheckerTests.swift */,
 				87901778724DEE9DD5AF6172 /* UserPreferencesDisconnectedIconTests.swift */,
@@ -827,6 +830,7 @@
 				E9279EFBCC8FA8185B76F545 /* StatusPresenterTests.swift in Sources */,
 				D2CC8BA3A6CD70DE9048A37F /* StubLoginItemServiceTests.swift in Sources */,
 				284FC73F9292B38E160184BE /* StubNotificationServiceTests.swift in Sources */,
+				82BE0F10C9B8A185876900FF /* TempCardArrowStateTests.swift in Sources */,
 				9093B301D07F6A6F9779E0FA /* ThemeAccentTests.swift in Sources */,
 				A8489CBBF57A00D4167BE433 /* UpdateCheckerTests.swift in Sources */,
 				1B8D7B3BF1BA82DCA82561B9 /* UserPreferencesDisconnectedIconTests.swift in Sources */,

--- a/PrusaStatusBar/UI/Components/TempCard.swift
+++ b/PrusaStatusBar/UI/Components/TempCard.swift
@@ -23,6 +23,14 @@ struct TempCard: View {
         }
     }
 
+    enum ArrowState {
+        case heating
+        case cooling
+        case none
+    }
+
+    static let ambientThresholdCelsius: Double = 40.0
+
     let heater: Heater
     let temperature: Temperature
 
@@ -42,9 +50,12 @@ struct TempCard: View {
                     Text(heater.label)
                         .prusaSectionHeader()
                 }
-                Text(currentString)
-                    .font(.prusaMetricSmall.monospacedDigit())
-                    .foregroundStyle(Theme.Palette.textPrimary)
+                HStack(spacing: 3) {
+                    Text(currentString)
+                        .font(.prusaMetricSmall.monospacedDigit())
+                        .foregroundStyle(Theme.Palette.textPrimary)
+                    arrowView
+                }
                 if temperature.target > 0 {
                     Text(String(format: L10n.t("dropdown.metrics.temp.target"), Int(temperature.target.rounded())))
                         .font(.prusaCaption.monospacedDigit())
@@ -67,11 +78,43 @@ struct TempCard: View {
         "\(Int(temperature.current.rounded()))°"
     }
 
-    private var accessibilityValue: String {
-        if temperature.target > 0 {
-            return "\(Int(temperature.current.rounded())) degrees, target \(Int(temperature.target.rounded()))"
+    var arrowState: ArrowState {
+        if temperature.target > 0, temperature.current < temperature.target {
+            return .heating
         }
-        return "\(Int(temperature.current.rounded())) degrees"
+        if temperature.target == 0, temperature.current > Self.ambientThresholdCelsius {
+            return .cooling
+        }
+        return .none
+    }
+
+    @ViewBuilder
+    private var arrowView: some View {
+        switch arrowState {
+        case .heating:
+            Image(systemName: "arrow.up.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Theme.Palette.statePrintingOrange)
+        case .cooling:
+            Image(systemName: "arrow.down.right")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(Theme.Palette.stateCoolingBlue)
+        case .none:
+            EmptyView()
+        }
+    }
+
+    private var accessibilityValue: String {
+        var base = "\(Int(temperature.current.rounded())) degrees"
+        if temperature.target > 0 {
+            base += ", target \(Int(temperature.target.rounded()))"
+        }
+        switch arrowState {
+        case .heating: base += ", heating"
+        case .cooling: base += ", cooling"
+        case .none: break
+        }
+        return base
     }
 
     private var ratio: Double {
@@ -101,9 +144,19 @@ struct TempCard: View {
 
 #if DEBUG
     #Preview {
-        HStack(spacing: 8) {
-            TempCard(heater: .nozzle, temperature: Temperature(current: 215, target: 230))
-            TempCard(heater: .bed, temperature: Temperature(current: 58, target: 60))
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                TempCard(heater: .nozzle, temperature: Temperature(current: 45, target: 230)) // heating
+                TempCard(heater: .bed, temperature: Temperature(current: 58, target: 60)) // heating
+            }
+            HStack(spacing: 8) {
+                TempCard(heater: .nozzle, temperature: Temperature(current: 230, target: 230)) // at target
+                TempCard(heater: .bed, temperature: Temperature(current: 80, target: 0)) // cooling
+            }
+            HStack(spacing: 8) {
+                TempCard(heater: .nozzle, temperature: Temperature(current: 22, target: 0)) // cold, no arrow
+                TempCard(heater: .bed, temperature: Temperature(current: 215, target: 230)) // heating
+            }
         }
         .padding()
         .frame(width: 360)

--- a/PrusaStatusBar/UI/Theme/Theme.swift
+++ b/PrusaStatusBar/UI/Theme/Theme.swift
@@ -74,6 +74,7 @@ public enum Theme {
 
         public static let statePrintingOrange = Color("BrandOrange")
         public static let statePrintingOrangeMuted = Color("BrandOrangeMuted")
+        public static let stateCoolingBlue = Color.blue
     }
 
     public enum Spacing {

--- a/PrusaStatusBarTests/TempCardArrowStateTests.swift
+++ b/PrusaStatusBarTests/TempCardArrowStateTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+@testable import PrusaStatusBar
+import Testing
+
+/// Spec coverage:
+/// - `menu-bar-ui` Requirement: Temperature Direction Indicator
+@MainActor
+struct TempCardArrowStateTests {
+    private func card(_ current: Double, target: Double) -> TempCard {
+        TempCard(heater: .nozzle, temperature: Temperature(current: current, target: target))
+    }
+
+    @Test
+    func heatingArrow_belowTarget() {
+        #expect(card(45, target: 230).arrowState == .heating)
+    }
+
+    @Test
+    func heatingArrow_justBelowTarget() {
+        #expect(card(229, target: 230).arrowState == .heating)
+    }
+
+    @Test
+    func noArrow_atTarget() {
+        #expect(card(230, target: 230).arrowState == .none)
+    }
+
+    @Test
+    func noArrow_aboveTarget() {
+        #expect(card(231, target: 230).arrowState == .none)
+    }
+
+    @Test
+    func coolingArrow_noTargetHot() {
+        #expect(card(80, target: 0).arrowState == .cooling)
+    }
+
+    @Test
+    func coolingArrow_justAboveThreshold() {
+        #expect(card(TempCard.ambientThresholdCelsius + 0.1, target: 0).arrowState == .cooling)
+    }
+
+    @Test
+    func noArrow_noTargetAtThreshold() {
+        #expect(card(TempCard.ambientThresholdCelsius, target: 0).arrowState == .none)
+    }
+
+    @Test
+    func noArrow_noTargetCold() {
+        #expect(card(22, target: 0).arrowState == .none)
+    }
+}


### PR DESCRIPTION
<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

Add cooldown/heat arrows

## Screenshots / GIFs

<img width="688" height="182" alt="screenshot_2026-05-16_12 24 38@2x" src="https://github.com/user-attachments/assets/6c1e0ed3-5d97-40ae-be3b-e71eeba538a0" />

## Checklist

- [X] Tests added or updated (Swift Testing).
- [X] `just check` passes locally.
- [X] `just test` passes locally.
- [X] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [X] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Add visual indicators for temperature heating and cooling states in the temperature card UI and cover the new behavior with tests.

New Features:
- Show directional arrows next to the current temperature to indicate when a heater is warming up or cooling down, based on target and ambient thresholds.

Tests:
- Add unit tests for TempCard arrow state logic across heating, cooling, and idle scenarios.