### PR TITLE
fix: loadedURL guard blocks any future reinstall, the player stays de…

### DIFF
--- a/PrusaStatusBar/Services/GoRTCService.swift
+++ b/PrusaStatusBar/Services/GoRTCService.swift
@@ -201,6 +201,10 @@ final class GoRTCService {
         // spinning, so callers (popoverDidClose) return immediately. Probe
         // liveness via `kill(pid, 0)` so we do not need to capture the
         // non-Sendable `Process`.
+        // The PID file is intentionally left in place here so that
+        // killOrphanIfNeeded() can find and kill this process on the next
+        // applyStreams call (fast reopen race). reapStaleHelper() handles
+        // cleanup on the next app launch if needed.
         let pid = proc.processIdentifier
         let escalationLogger = logger
         Task.detached {
@@ -215,7 +219,6 @@ final class GoRTCService {
                 _ = Darwin.kill(pid, SIGKILL)
             }
         }
-        removePIDFile()
     }
 
     /// Called by `AppDelegate.applicationDidFinishLaunching` before any UI
@@ -398,12 +401,23 @@ extension GoRTCService {
         guard
             let raw = try? String(contentsOf: dependencies.pidFileURL, encoding: .utf8),
             let pid = pid_t(raw.trimmingCharacters(in: .whitespacesAndNewlines)),
-            pid != process?.processIdentifier,
-            isProcessAlive(pid),
-            pidLooksLikeHelper(pid)
+            pid != process?.processIdentifier
         else { return }
+        guard isProcessAlive(pid) else {
+            removePIDFile()
+            return
+        }
+        guard pidLooksLikeHelper(pid) else {
+            removePIDFile()
+            return
+        }
         logger.warning("killing orphaned go2rtc pid=\(pid, privacy: .public)")
         Darwin.kill(pid, SIGKILL)
+        // Wait for the process to die so port 1984 is free before start().
+        let deadline = Date().addingTimeInterval(0.3)
+        while isProcessAlive(pid), Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.02)
+        }
         removePIDFile()
     }
 

--- a/PrusaStatusBar/UI/Components/CameraPlayer.swift
+++ b/PrusaStatusBar/UI/Components/CameraPlayer.swift
@@ -147,12 +147,22 @@
 
         private func scheduleRetry() {
             guard let url = loadedURL else { return }
-            guard retryAttempt < retryBackoffs.count else {
-                failureExhaustedHandler?()
-                return
+            let delay: TimeInterval
+            if retryAttempt < retryBackoffs.count {
+                delay = retryBackoffs[retryAttempt]
+                retryAttempt += 1
+            } else {
+                // Fast budget exhausted. Notify the fallback handler exactly
+                // once, then switch to a slow 10s periodic retry so the tile
+                // self-heals when go2rtc eventually delivers the stream
+                // (e.g. camera with a very long keyframe interval).
+                // tearDown() cancels pendingRetry, so retries stop on close.
+                if retryAttempt == retryBackoffs.count {
+                    failureExhaustedHandler?()
+                    retryAttempt += 1
+                }
+                delay = 10.0
             }
-            let delay = retryBackoffs[retryAttempt]
-            retryAttempt += 1
             pendingRetry?.cancel()
             pendingRetry = Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))

--- a/PrusaStatusBarTests/GoRTCServiceLifecycleTests.swift
+++ b/PrusaStatusBarTests/GoRTCServiceLifecycleTests.swift
@@ -24,11 +24,15 @@ struct GoRTCServiceLifecycleTests {
 
         service.stop()
 
-        // PID file is removed on stop.
-        #expect(FileManager.default.fileExists(atPath: paths.pidFileURL.path) == false)
-        // No pid leak in the C-level slot used by the atexit fallback.
-        // (We can only observe indirectly via stop being idempotent.)
+        // PID file is intentionally left in place after stopping a live
+        // process so killOrphanIfNeeded() can reap the (possibly still-
+        // terminating) process on the next applyStreams call.
+        #expect(FileManager.default.fileExists(atPath: paths.pidFileURL.path) == true)
+
+        // A second stop() (nil-process path) removes the stale file as a
+        // defensive cleanup and is idempotent.
         service.stop()
+        #expect(FileManager.default.fileExists(atPath: paths.pidFileURL.path) == false)
     }
 
     @Test


### PR DESCRIPTION
…ad forever + better SIGTERM management

<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

loadedURL guard blocks any future reinstall, the player stays dead forever + better SIGTERM management

## Checklist

- [X] Tests added or updated (Swift Testing).
- [X] `just check` passes locally.
- [X] `just test` passes locally.
- [X] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [X] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Adjust go2rtc helper lifecycle and camera player retry behavior to avoid permanent failure after stoppage and improve process cleanup.

Bug Fixes:
- Prevent the camera player from staying permanently dead by continuing slow periodic retries after fast retry budget is exhausted.
- Ensure orphaned go2rtc helper processes are correctly detected, killed, and have their PID files cleaned up, avoiding port conflicts on restart.

Enhancements:
- Leave the PID file in place after stopping a live go2rtc process so subsequent launches can reliably reap still-terminating helpers.
- Wait briefly for killed orphan go2rtc processes to exit to free the listening port before starting a new helper.
- Refine GoRTCService stop behavior to keep it idempotent while adding defensive PID file cleanup on repeated stops.

Tests:
- Update GoRTCService lifecycle tests to reflect the new PID file lifecycle and idempotent stop behavior.