### PR TITLE
refactor: update api key helper tooltip #14

### DIFF
--- a/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "Více informací";
 "common.help.learn_more"                  = "Zjistit více";
 "printer.help.url.body"                   = "Zadejte http://<ip> nebo http://<hostname> své tiskárny (například http://192.168.1.42 nebo http://prusa-mk3.local). Nejprve adresu otevřete ve webovém prohlížeči a ověřte, že se PrusaLink načte.";
-"printer.help.api_key.body"               = "API klíč pro tuto tiskárnu najdete v Prusa Connect.";
+"printer.help.api_key.body"               = "PrusaLink API klíč pro tuto tiskárnu najdete v Prusa Connect.";
 "printer.help.camera.body"                = "Zadejte IP adresu nebo hostname Buddy Camery (například 192.168.1.42 nebo buddy-cam.local).\n\nDůležité: RTSP je u Buddy Camery ve výchozím stavu VYPNUTÉ. Povolte ho v PrusaConnect v Kamera > Ovládání kamery, jinak se dlaždice nepřipojí.";
 "printer.help.uuid.body"                  = "Toto UUID najdete v nastavení tiskárny v Prusa Connect. Volitelné: nechte prázdné, pokud Prusa Connect nepoužíváte.";
 "printer.test.connected"                  = "Připojeno";

--- a/PrusaStatusBar/Resources/de.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/de.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "Mehr Infos";
 "common.help.learn_more"                  = "Mehr erfahren";
 "printer.help.url.body"                   = "Geben Sie http://<ip> oder http://<hostname> Ihres Druckers ein (zum Beispiel http://192.168.1.42 oder http://prusa-mk3.local). Öffnen Sie die Adresse zuerst in Ihrem Webbrowser, um sicherzustellen, dass PrusaLink geladen wird.";
-"printer.help.api_key.body"               = "Den API-Schlüssel finden Sie für diesen Drucker in Prusa Connect.";
+"printer.help.api_key.body"               = "Den PrusaLink-API-Schlüssel finden Sie für diesen Drucker in Prusa Connect.";
 "printer.help.camera.body"                = "Geben Sie die IP oder den Hostnamen der Buddy Camera ein (zum Beispiel 192.168.1.42 oder buddy-cam.local).\n\nWichtig: Bei der Buddy Camera ist RTSP standardmäßig DEAKTIVIERT. Aktivieren Sie es in PrusaConnect unter Kamera > Kamerasteuerung, sonst kann die Kachel keine Verbindung aufbauen.";
 "printer.help.uuid.body"                  = "Diese UUID finden Sie in den Druckereinstellungen in Prusa Connect. Optional: leer lassen, wenn Sie Prusa Connect nicht nutzen.";
 "printer.test.connected"                  = "Verbunden";

--- a/PrusaStatusBar/Resources/en.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/en.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 "common.help.tooltip"                     = "More info";
 "common.help.learn_more"                  = "Learn more";
 "printer.help.url.body"                   = "Enter http://<ip> or http://<hostname> of your printer (for example http://192.168.1.42 or http://prusa-mk3.local). Open it in your web browser first to confirm PrusaLink loads.";
-"printer.help.api_key.body"               = "Find the API key on Prusa Connect for this printer.";
+"printer.help.api_key.body"               = "Find the PrusaLink API key on Prusa Connect for this printer.";
 "printer.help.camera.body"                = "Enter the IP or hostname of the Buddy Camera (for example 192.168.1.42 or buddy-cam.local).\n\nImportant: RTSP is OFF by default on the Buddy Camera. Enable it in PrusaConnect under Camera > Camera control, otherwise the tile cannot connect.";
 "printer.help.uuid.body"                  = "Find this UUID in the printer's settings on Prusa Connect. Optional: leave blank if you do not use Prusa Connect.";
 "printer.test.connected"                  = "Connected";

--- a/PrusaStatusBar/Resources/es.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/es.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "Más información";
 "common.help.learn_more"                  = "Más información";
 "printer.help.url.body"                   = "Introduce http://<ip> o http://<nombre_de_host> de tu impresora (por ejemplo http://192.168.1.42 o http://prusa-mk3.local). Ábrela primero en tu navegador para confirmar que PrusaLink se carga.";
-"printer.help.api_key.body"               = "Encuentra la clave API de esta impresora en Prusa Connect.";
+"printer.help.api_key.body"               = "Encuentra la clave API de PrusaLink de esta impresora en Prusa Connect.";
 "printer.help.camera.body"                = "Introduce la IP o el nombre de host de la Buddy Camera (por ejemplo 192.168.1.42 o buddy-cam.local).\n\nImportante: en la Buddy Camera, RTSP está DESACTIVADO por defecto. Actívalo en PrusaConnect en Cámara > Control de cámara, de lo contrario la imagen no podrá conectarse.";
 "printer.help.uuid.body"                  = "Encuentra este UUID en los ajustes de la impresora en Prusa Connect. Opcional: déjalo en blanco si no usas Prusa Connect.";
 "printer.test.connected"                  = "Conectada";

--- a/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "Plus d'infos";
 "common.help.learn_more"                  = "En savoir plus";
 "printer.help.url.body"                   = "Saisissez http://<ip> ou http://<nom_d_hote> de votre imprimante (par exemple http://192.168.1.42 ou http://prusa-mk3.local). Ouvrez l'adresse dans votre navigateur web pour vérifier que PrusaLink se charge.";
-"printer.help.api_key.body"               = "Retrouvez la clé API sur Prusa Connect pour cette imprimante.";
+"printer.help.api_key.body"               = "Retrouvez la clé API PrusaLink sur Prusa Connect pour cette imprimante.";
 "printer.help.camera.body"                = "Saisissez l'IP ou le nom d'hôte de la Buddy Camera (par exemple 192.168.1.42 ou buddy-cam.local).\n\nImportant : sur la Buddy Camera, le RTSP est DÉSACTIVÉ par défaut. Activez-le dans PrusaConnect via Caméra > Contrôle de la caméra, sinon la tuile ne pourra pas se connecter.";
 "printer.help.uuid.body"                  = "Retrouvez cet UUID dans les paramètres de l'imprimante sur Prusa Connect. Optionnel : laissez vide si vous n'utilisez pas Prusa Connect.";
 "printer.test.connected"                  = "Connectée";

--- a/PrusaStatusBar/Resources/it.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/it.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "Maggiori info";
 "common.help.learn_more"                  = "Scopri di più";
 "printer.help.url.body"                   = "Inserisci http://<ip> o http://<hostname> della tua stampante (per esempio http://192.168.1.42 o http://prusa-mk3.local). Aprilo prima nel browser web per verificare che PrusaLink si carichi.";
-"printer.help.api_key.body"               = "Trovi la chiave API di questa stampante su Prusa Connect.";
+"printer.help.api_key.body"               = "Trovi la chiave API di PrusaLink di questa stampante su Prusa Connect.";
 "printer.help.camera.body"                = "Inserisci l'IP o l'hostname della Buddy Camera (per esempio 192.168.1.42 o buddy-cam.local).\n\nImportante: sulla Buddy Camera RTSP è DISATTIVATO di default. Attivalo in PrusaConnect in Telecamera > Controllo telecamera, altrimenti il riquadro non potrà connettersi.";
 "printer.help.uuid.body"                  = "Trovi questo UUID nelle impostazioni della stampante su Prusa Connect. Opzionale: lascia vuoto se non usi Prusa Connect.";
 "printer.test.connected"                  = "Connessa";

--- a/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "詳細情報";
 "common.help.learn_more"                  = "詳しく見る";
 "printer.help.url.body"                   = "プリンターの http://<ip> または http://<hostname> を入力してください（例: http://192.168.1.42 または http://prusa-mk3.local）。先にブラウザでアドレスを開き、PrusaLink が表示されることを確認してください。";
-"printer.help.api_key.body"               = "API キーは Prusa Connect 上のこのプリンターのページで確認できます。";
+"printer.help.api_key.body"               = "PrusaLink の API キーは Prusa Connect 上のこのプリンターのページで確認できます。";
 "printer.help.camera.body"                = "Buddy Camera の IP またはホスト名を入力してください（例: 192.168.1.42 または buddy-cam.local）。\n\n重要: Buddy Camera では RTSP は既定で無効です。PrusaConnect の Camera > Camera control から有効にしてください。有効にしないとタイルは接続できません。";
 "printer.help.uuid.body"                  = "この UUID は Prusa Connect のプリンター設定で確認できます。任意項目: Prusa Connect を使用しない場合は空欄のままで構いません。";
 "printer.test.connected"                  = "接続済み";

--- a/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "Więcej informacji";
 "common.help.learn_more"                  = "Dowiedz się więcej";
 "printer.help.url.body"                   = "Wprowadź http://<ip> lub http://<hostname> swojej drukarki (na przykład http://192.168.1.42 lub http://prusa-mk3.local). Najpierw otwórz adres w przeglądarce, aby potwierdzić, że PrusaLink się ładuje.";
-"printer.help.api_key.body"               = "Klucz API tej drukarki znajdziesz w Prusa Connect.";
+"printer.help.api_key.body"               = "Klucz API PrusaLink tej drukarki znajdziesz w Prusa Connect.";
 "printer.help.camera.body"                = "Wprowadź IP lub nazwę hosta kamery Buddy (na przykład 192.168.1.42 lub buddy-cam.local).\n\nWażne: w Buddy Camera RTSP jest domyślnie WYŁĄCZONE. Włącz je w PrusaConnect w sekcji Kamera > Sterowanie kamerą, inaczej kafelek się nie połączy.";
 "printer.help.uuid.body"                  = "Ten UUID znajdziesz w ustawieniach drukarki w Prusa Connect. Opcjonalne: pozostaw puste, jeśli nie używasz Prusa Connect.";
 "printer.test.connected"                  = "Połączono";

--- a/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "Mais informações";
 "common.help.learn_more"                  = "Saiba mais";
 "printer.help.url.body"                   = "Informe http://<ip> ou http://<hostname> da sua impressora (por exemplo http://192.168.1.42 ou http://prusa-mk3.local). Abra primeiro no navegador para confirmar que o PrusaLink carrega.";
-"printer.help.api_key.body"               = "Encontre a chave de API desta impressora no Prusa Connect.";
+"printer.help.api_key.body"               = "Encontre a chave de API do PrusaLink desta impressora no Prusa Connect.";
 "printer.help.camera.body"                = "Informe o IP ou hostname da Buddy Camera (por exemplo 192.168.1.42 ou buddy-cam.local).\n\nImportante: na Buddy Camera, o RTSP vem DESATIVADO por padrão. Ative-o no PrusaConnect em Câmera > Controle da câmera, caso contrário o bloco não conseguirá conectar.";
 "printer.help.uuid.body"                  = "Encontre este UUID nas configurações da impressora no Prusa Connect. Opcional: deixe em branco se não usa o Prusa Connect.";
 "printer.test.connected"                  = "Conectada";

--- a/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -166,7 +166,7 @@
 "common.help.tooltip"                     = "更多信息";
 "common.help.learn_more"                  = "了解更多";
 "printer.help.url.body"                   = "请输入打印机的 http://<ip> 或 http://<hostname>（例如 http://192.168.1.42 或 http://prusa-mk3.local）。先在浏览器中打开该地址，确认 PrusaLink 能够加载。";
-"printer.help.api_key.body"               = "可在 Prusa Connect 中找到此打印机的 API 密钥。";
+"printer.help.api_key.body"               = "可在 Prusa Connect 中找到此打印机的 PrusaLink API 密钥。";
 "printer.help.camera.body"                = "请输入 Buddy Camera 的 IP 或主机名（例如 192.168.1.42 或 buddy-cam.local）。\n\n重要：Buddy Camera 默认关闭 RTSP。请前往 PrusaConnect 的 Camera > Camera control 启用，否则相机方块将无法连接。";
 "printer.help.uuid.body"                  = "可以在 Prusa Connect 中此打印机的设置里找到该 UUID。可选：如果不使用 Prusa Connect，可留空。";
 "printer.test.connected"                  = "已连接";


### PR DESCRIPTION
<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

update api key helper tooltip

## Checklist

- [X] Tests added or updated (Swift Testing).
- [X] `just check` passes locally.
- [X] `just test` passes locally.
- [X] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [X] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Enhancements:
- Refresh API key helper tooltip copy in all Localizable.strings files for supported locales.