### PR TITLE
fix: go2rtc wrong arch pickup for intel cpus #4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
             clean build
           lipo -info "build/Build/Products/Release/PrusaStatusBar.app/Contents/MacOS/PrusaStatusBar"
 
+      - name: Verify bundled go2rtc arch matches ${{ matrix.arch }}
+        run: ./scripts/verify-go2rtc-arch.sh "build/Build/Products/Release/PrusaStatusBar.app" "${{ matrix.arch }}"
+
       - name: Package DMG (ad-hoc signed)
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,9 @@ jobs:
           # Sanity check: confirm the main binary is single-arch for this matrix slice.
           lipo -info "build/Build/Products/Release/PrusaStatusBar.app/Contents/MacOS/PrusaStatusBar"
 
+      - name: Verify bundled go2rtc arch matches ${{ matrix.arch }}
+        run: ./scripts/verify-go2rtc-arch.sh "build/Build/Products/Release/PrusaStatusBar.app" "${{ matrix.arch }}"
+
       - name: Package, sign, notarize, staple DMG
         env:
           MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ check-version:
     @./scripts/check-version-sync.sh
 
 # Generate Xcode project from project.yml (idempotent)
-gen: doctor fetch-go2rtc
+gen: doctor
     @command -v xcodegen >/dev/null || { echo "xcodegen not found. Install: brew install xcodegen"; exit 1; }
     {{rtk}} xcodegen generate
 
@@ -52,7 +52,7 @@ format: swift-tools-check
 check: lint format-check
 
 # Run the test suite
-test: gen
+test: gen fetch-go2rtc
     set -o pipefail; {{rtk}} xcodebuild test \
         -project {{project}} \
         -scheme {{scheme}} \
@@ -65,7 +65,7 @@ test: gen
             CODE_SIGNING_ALLOWED=NO
 
 # Debug build
-build: gen
+build: gen fetch-go2rtc
     if [ -f apple_sign.env ]; then set -a; . ./apple_sign.env; set +a; fi; \
     SIGN_ID="${MACOS_SIGN_IDENTITY:--}"; \
     TEAM_ID="${MACOS_TEAM_ID:-}"; \
@@ -79,7 +79,7 @@ build: gen
         DEVELOPMENT_TEAM="$TEAM_ID"
 
 # Prototype build (no real network calls; uses in-memory stub client)
-build-prototype: gen
+build-prototype: gen fetch-go2rtc
     if [ -f apple_sign.env ]; then set -a; . ./apple_sign.env; set +a; fi; \
     SIGN_ID="${MACOS_SIGN_IDENTITY:--}"; \
     TEAM_ID="${MACOS_TEAM_ID:-}"; \
@@ -93,7 +93,7 @@ build-prototype: gen
         DEVELOPMENT_TEAM="$TEAM_ID"
 
 # Release build (Developer ID from apple_sign.env if present, else ad-hoc)
-build-release: gen
+build-release: gen fetch-go2rtc
     if [ -f apple_sign.env ]; then set -a; . ./apple_sign.env; set +a; fi; \
     SIGN_ID="${MACOS_SIGN_IDENTITY:--}"; \
     TEAM_ID="${MACOS_TEAM_ID:-}"; \

--- a/scripts/fetch-go2rtc.sh
+++ b/scripts/fetch-go2rtc.sh
@@ -11,7 +11,7 @@ VERSION="v1.9.14"
 ARM64_ASSET="go2rtc_mac_arm64.zip"
 ARM64_SHA="6e5039d56d652d2d325cb3ce3f7cc20248a34db42fe8abf9bb13488494ac023e"
 AMD64_ASSET="go2rtc_mac_amd64.zip"
-AMD64_SHA=""
+AMD64_SHA="9beb1d730447729337dbe40218126cb41392aad94b427ec1099837c85fe1a4aa"
 
 # Resolve the destination relative to the repo root.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -72,6 +72,21 @@ case "$ARCH" in
     x86_64) ASSET="$AMD64_ASSET"; SHA="$AMD64_SHA" ;;
     *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
 esac
+
+# Arch-aware skip: if a binary is already on disk but for the wrong arch
+# (e.g. a prior `just gen` ran without ARCH, or a stale cache restored the
+# native-arch helper), drop it so the SHA check below re-downloads.
+if [[ -f "$DEST" ]]; then
+    have_arch="$(lipo -archs "$DEST" 2>/dev/null || file -b "$DEST")"
+    case "$ARCH" in
+        arm64)  expect="arm64" ;;
+        x86_64) expect="x86_64" ;;
+    esac
+    if [[ "$have_arch" != *"$expect"* ]]; then
+        echo "go2rtc on disk is '$have_arch', want $expect; re-downloading"
+        rm -f "$DEST"
+    fi
+fi
 
 if [[ -f "$DEST" && -n "$SHA" ]]; then
     actual="$(shasum -a 256 "$DEST" | awk '{print $1}')"

--- a/scripts/verify-go2rtc-arch.sh
+++ b/scripts/verify-go2rtc-arch.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Verify the go2rtc helper bundled inside a built PrusaStatusBar.app matches
+# an expected architecture. Used by CI/release workflows to catch a regression
+# where the wrong-arch helper ends up in the .app (see PR #16).
+#
+# Usage: scripts/verify-go2rtc-arch.sh <app-path> <expected-arch>
+#   expected-arch: arm64 | x86_64
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <app-path> <expected-arch>" >&2
+    exit 2
+fi
+
+APP="$1"
+EXPECT="$2"
+BIN="$APP/Contents/Resources/go2rtc"
+
+if [[ ! -f "$BIN" ]]; then
+    echo "go2rtc helper missing from app bundle at $BIN" >&2
+    exit 1
+fi
+
+file "$BIN"
+ARCHS="$(lipo -archs "$BIN")"
+echo "go2rtc archs: $ARCHS"
+
+if ! grep -qw "$EXPECT" <<<"$ARCHS"; then
+    echo "ARCH MISMATCH: bundled go2rtc is '$ARCHS' but expected $EXPECT" >&2
+    exit 1
+fi


### PR DESCRIPTION
<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

go2rtc wrong arch pickup for intel cpus

## Checklist

- [X] Tests added or updated (Swift Testing).
- [X] `just check` passes locally.
- [X] `just test` passes locally.
- [X] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [X] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Ensure the bundled go2rtc helper matches the target architecture and improve its fetching logic to avoid wrong-arch binaries ending up in builds.

Build:
- Stop invoking go2rtc fetching as part of the generic Xcode project generation command, decoupling helper download from project generation.

CI:
- Add a CI step in both standard and release workflows to verify that the bundled go2rtc binary’s architecture matches the current build matrix architecture.

Chores:
- Provide the missing checksum for the amd64 go2rtc asset and add arch-aware validation to re-download the helper when an on-disk binary is for the wrong architecture.