### PR TITLE
fix: fix various refresh issues #19 #20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 permissions:

--- a/PrusaStatusBar.xcodeproj/project.pbxproj
+++ b/PrusaStatusBar.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		35975DB57C0F2315DB960E6F /* ProgressBarStylePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F490F5BC72EDF7C8E42D82 /* ProgressBarStylePreview.swift */; };
 		35FE62554F2D7E0B5C141A87 /* JobBackdropRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B037059349E8C2151A0F30 /* JobBackdropRenderer.swift */; };
 		360539A7C9FD2F0CD8C9C239 /* FieldValidationCaption.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98BC8C8787FF5C5A879E043 /* FieldValidationCaption.swift */; };
+		374C41BFE40E321D6F783422 /* PollingCoordinatorJobIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5CD1FFD05A1DF0B8665CF8 /* PollingCoordinatorJobIdentityTests.swift */; };
 		37B645A9E57F74D3865BE7E5 /* CustomActionsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD03C88656C9307469ABB62 /* CustomActionsRow.swift */; };
 		385D0171E159EFFFDFFAF0BE /* HeroHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F5D13FCC5216930FC64DE7 /* HeroHeader.swift */; };
 		394CD875B62CAC03465FC1CE /* PrusaStatusBarApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B0400EE85F3DABF3548727 /* PrusaStatusBarApp.swift */; };
@@ -121,6 +122,7 @@
 		912F3B777DCBB3348FFD2FEA /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA64459A313499CD472179F /* SemanticVersion.swift */; };
 		94875CF3FA408DE4BB66971D /* CameraSnapshotProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92BE5989CA4A26FD7C81AA6 /* CameraSnapshotProvider.swift */; };
 		94BC313C832769CE6B61BC6A /* UserPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4526FE5ADC7EA3CB56022219 /* UserPreferences.swift */; };
+		9581662EA14D2345643BE9EB /* DetachedStatusWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9916905DD6C79C30EC6AB9 /* DetachedStatusWindowControllerTests.swift */; };
 		95FCD2DB524D4A425CB0E712 /* CustomActionConfirmDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7CF1047D4B69AB79344E6C /* CustomActionConfirmDialog.swift */; };
 		9892F61C7B50D5C7750441C4 /* PreferencesWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 796B7A9C12A1BD276619A187 /* PreferencesWindow.swift */; };
 		99B85BE321C085470AAA8E3A /* UserPreferences+CustomActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1DAA7E6CB94AE41C7F7F1F4 /* UserPreferences+CustomActions.swift */; };
@@ -144,6 +146,7 @@
 		B09EDD67EB0806675A154C0F /* FooterBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE76CF22C0FD564C030BFF6 /* FooterBar.swift */; };
 		B5C1FFE030E3C8981CC923A2 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47070FEC5E436443EFBE7A65 /* NotificationService.swift */; };
 		B6DC0419AD06204E8E265296 /* PrinterNotificationHintSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1507E96DA6DB70A88B90A132 /* PrinterNotificationHintSection.swift */; };
+		B7F688E901D926D61B152ECF /* DropdownContentHeightReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19AF981EAF5C32CDE22452E2 /* DropdownContentHeightReporter.swift */; };
 		B88A57CF12CDB121D6384DDA /* PrinterTab+Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56E480080DDB6D31572A308 /* PrinterTab+Keychain.swift */; };
 		B94E1A2CE999DAD838DDED0F /* GenericCameraSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6C900410D28FA13A512271 /* GenericCameraSection.swift */; };
 		BADF66BA72FB74221270BD03 /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C145F93387C418D7650EC7 /* UpdateChecker.swift */; };
@@ -222,9 +225,12 @@
 		15B02F4751AAAF8DC15616DD /* TempCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempCard.swift; sourceTree = "<group>"; };
 		16026281D1D3478F07405152 /* L10n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
 		18244F0F7CC4EBE6D3B11A1E /* UserPreferencesProgressBarStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferencesProgressBarStyleTests.swift; sourceTree = "<group>"; };
+		19AF981EAF5C32CDE22452E2 /* DropdownContentHeightReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownContentHeightReporter.swift; sourceTree = "<group>"; };
 		1AA64459A313499CD472179F /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
 		1AEED496B206A04CA4624F10 /* SpoolThumb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpoolThumb.swift; sourceTree = "<group>"; };
+		1B5CD1FFD05A1DF0B8665CF8 /* PollingCoordinatorJobIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinatorJobIdentityTests.swift; sourceTree = "<group>"; };
 		1BB8DDF00E85C7426610E690 /* SemanticVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersionTests.swift; sourceTree = "<group>"; };
+		1C9916905DD6C79C30EC6AB9 /* DetachedStatusWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetachedStatusWindowControllerTests.swift; sourceTree = "<group>"; };
 		1DF85DFCC98EB910E6288132 /* StubNotificationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubNotificationServiceTests.swift; sourceTree = "<group>"; };
 		216B96195B97D19C9A2ADFA4 /* RunningInstancesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningInstancesProvider.swift; sourceTree = "<group>"; };
 		246830651D2DF55BEFDE45B3 /* GoRTCService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoRTCService.swift; sourceTree = "<group>"; };
@@ -411,6 +417,7 @@
 				E47401C33A9E6885BFF765E0 /* CustomActionSlotCard.swift */,
 				DCD03C88656C9307469ABB62 /* CustomActionsRow.swift */,
 				5F74880505D4E63902C3FBF7 /* DisconnectedIconStylePicker.swift */,
+				19AF981EAF5C32CDE22452E2 /* DropdownContentHeightReporter.swift */,
 				E98BC8C8787FF5C5A879E043 /* FieldValidationCaption.swift */,
 				DFE76CF22C0FD564C030BFF6 /* FooterBar.swift */,
 				EC7D035DB58E2A9E6B28BC72 /* FormCaptionRow.swift */,
@@ -593,6 +600,7 @@
 				9FBF70FB14FE78E30605FEC2 /* CustomActionRunnerTests.swift */,
 				9BFF41CEF90DA97FE483BB77 /* CustomActionSecretsStoreTests.swift */,
 				9A968828F6B57CE1CC1BD3EC /* CustomActionTests.swift */,
+				1C9916905DD6C79C30EC6AB9 /* DetachedStatusWindowControllerTests.swift */,
 				A132036C7DED65BA4492AA41 /* DropdownJobCardVisibilityTests.swift */,
 				D7FCE09AA55A9877E8DDA102 /* DropdownPrusaLinkButtonGateTests.swift */,
 				679B3A8A09BE04C93111B7D2 /* GenericCameraConfigTests.swift */,
@@ -606,6 +614,7 @@
 				0DF48E150DEE3575323D5D3F /* MJPEGFrameGrabberTests.swift */,
 				30E3FC2A623E22E09E74C73A /* PollingCoordinatorBurstTokenTests.swift */,
 				01E6CDDD0D76BB029B8825B7 /* PollingCoordinatorIntervalTests.swift */,
+				1B5CD1FFD05A1DF0B8665CF8 /* PollingCoordinatorJobIdentityTests.swift */,
 				40820872A7703EB26D27F4E6 /* PopoverLifecycleTests.swift */,
 				D192C2F790D169C82B974C4B /* PrinterBaseURLValidatorTests.swift */,
 				5587386878C425BB00FB8A88 /* PrinterStateTests.swift */,
@@ -816,6 +825,7 @@
 				2EA6241879AC089F2DEF88AC /* CustomActionRunnerTests.swift in Sources */,
 				EEB612D3A53B1D92F7375A96 /* CustomActionSecretsStoreTests.swift in Sources */,
 				90608A85E07F0484F3E8EFA8 /* CustomActionTests.swift in Sources */,
+				9581662EA14D2345643BE9EB /* DetachedStatusWindowControllerTests.swift in Sources */,
 				3C735DAC8253D833E1F2B341 /* DropdownJobCardVisibilityTests.swift in Sources */,
 				F2A1D32767A6DCA8A1133FB1 /* DropdownPrusaLinkButtonGateTests.swift in Sources */,
 				6D4583262C27ED5F3A5A51CF /* GenericCameraConfigTests.swift in Sources */,
@@ -829,6 +839,7 @@
 				1B95F420FA666EFDD43074C4 /* MJPEGFrameGrabberTests.swift in Sources */,
 				4B8C3CDD6FD50821F23176BF /* PollingCoordinatorBurstTokenTests.swift in Sources */,
 				8BD0D270D5E8F2A37C5C3C08 /* PollingCoordinatorIntervalTests.swift in Sources */,
+				374C41BFE40E321D6F783422 /* PollingCoordinatorJobIdentityTests.swift in Sources */,
 				34D25079A797278C3DFD579A /* PopoverLifecycleTests.swift in Sources */,
 				D1A1E47B0D8ADA00CD560AFC /* PrinterBaseURLValidatorTests.swift in Sources */,
 				E534F68B76F0FC7AF72C2F9C /* PrinterStateTests.swift in Sources */,
@@ -893,6 +904,7 @@
 				5BF470FA703D65D9BC9DAD5D /* CustomActionsSection.swift in Sources */,
 				9FC2324164CC9C9EE1FE1291 /* DetachedStatusWindowController.swift in Sources */,
 				A572439161C5663B19496F00 /* DisconnectedIconStylePicker.swift in Sources */,
+				B7F688E901D926D61B152ECF /* DropdownContentHeightReporter.swift in Sources */,
 				86B855EEA0F810E156D4B2B6 /* DropdownView+CustomActions.swift in Sources */,
 				ADB0C7E9F133CCDF2809B11C /* DropdownView.swift in Sources */,
 				360539A7C9FD2F0CD8C9C239 /* FieldValidationCaption.swift in Sources */,

--- a/PrusaStatusBar/Services/CameraSnapshotProvider.swift
+++ b/PrusaStatusBar/Services/CameraSnapshotProvider.swift
@@ -28,9 +28,14 @@ struct BuddyCameraSnapshotProvider: CameraSnapshotProvider {
             "Buddy start; running=\(wasRunning, privacy: .public) t=\(timeout, privacy: .public)s"
         )
         do {
-            let data = try await GoRTCService.shared.snapshotJPEG(
-                streamName: GoRTCService.snapshotBuddyStreamName,
-                source: rtspURL,
+            // Route through the Buddy-specific helper so the snapshot
+            // request registers the same `streams:` source string
+            // (with `#transport=tcp`) the live CameraTile uses. Passing
+            // the raw RTSP URL here used to flip `applyStreams` into a
+            // restart, killing the live AVPlayer mid-print until the
+            // user closed and reopened the dropdown.
+            let data = try await GoRTCService.shared.snapshotBuddyJPEG(
+                rtspURL: rtspURL,
                 timeout: timeout
             )
             Log.cameraSnapshot.info("Buddy provider succeeded; bytes=\(data.count, privacy: .public)")

--- a/PrusaStatusBar/Services/GoRTCService+Snapshot.swift
+++ b/PrusaStatusBar/Services/GoRTCService+Snapshot.swift
@@ -26,6 +26,14 @@ extension GoRTCService {
     ///
     /// The helper lifecycle (start, stop) is the caller's responsibility;
     /// this method just uses whichever helper happens to be running.
+    ///
+    /// Buddy callers SHOULD go through `snapshotBuddyJPEG(rtspURL:timeout:)`
+    /// instead, which canonicalises the source through `withTCPTransport`
+    /// so the snapshot request registers an identical `streams:` entry to
+    /// the one the live `CameraTile` registers via `hlsURL(forRTSP:)`. If
+    /// the strings diverge by `#transport=tcp`, `applyStreams` flags
+    /// `needsRestart` and tears down the running helper mid-stream, which
+    /// freezes the dropdown tile until the user closes and reopens it.
     func snapshotJPEG(
         streamName: String,
         source: String,
@@ -57,6 +65,22 @@ extension GoRTCService {
             throw SnapshotError.invalidURL
         }
         return try await pollMP4Frame(url: url, deadline: deadline, started: started)
+    }
+
+    /// Buddy-slot wrapper that pairs the canonical Buddy stream-name
+    /// constant with the `withTCPTransport` transform the live tile uses.
+    /// Keeps the "Buddy slot is registered with TCP transport" invariant
+    /// owned by `GoRTCService` instead of each caller, so a snapshot
+    /// during an active live stream is a no-op for `applyStreams`.
+    func snapshotBuddyJPEG(
+        rtspURL: String,
+        timeout: TimeInterval = 3.0
+    ) async throws -> Data {
+        try await snapshotJPEG(
+            streamName: Self.snapshotBuddyStreamName,
+            source: withTCPTransport(rtspURL),
+            timeout: timeout
+        )
     }
 
     /// Retries the MP4 download + decode until success or deadline. On a

--- a/PrusaStatusBar/Services/PollingCoordinator.swift
+++ b/PrusaStatusBar/Services/PollingCoordinator.swift
@@ -170,7 +170,7 @@ public final class PollingCoordinator {
 
     private func applyStatus(_ status: PrinterStatus) async {
         let previous = previousState
-        let prevJobName = model.lastJob?.displayName
+        let prevJob = model.lastJob
 
         // Drive job/thumbnail refresh while a job is active, and on the
         // finished state so the popover can show the just-completed file when
@@ -178,9 +178,9 @@ public final class PollingCoordinator {
         // print finishes, so on `.finished` we preserve any cached job rather
         // than clearing it on a nil response.
         if status.state.isActive {
-            await refreshJobIfNeeded(previousFileName: prevJobName, clearWhenAbsent: true)
+            await refreshJobIfNeeded(previous: prevJob, clearWhenAbsent: true)
         } else if status.state == .finished {
-            await refreshJobIfNeeded(previousFileName: prevJobName, clearWhenAbsent: false)
+            await refreshJobIfNeeded(previous: prevJob, clearWhenAbsent: false)
         } else if status.state == .idle || status.state == .ready {
             // Drop the cached job when we're back to idle so the next active
             // print refetches the file detail / thumbnail.
@@ -198,7 +198,7 @@ public final class PollingCoordinator {
         previousState = status.state
     }
 
-    private func refreshJobIfNeeded(previousFileName: String?, clearWhenAbsent: Bool) async {
+    private func refreshJobIfNeeded(previous: PrintJob?, clearWhenAbsent: Bool) async {
         let result = await client.fetchJob()
         switch result {
         case let .success(job):
@@ -209,20 +209,46 @@ public final class PollingCoordinator {
                 }
                 return
             }
-            // Only download the thumbnail when the file changed.
-            let isSameFile = job.displayName == previousFileName
+            // Refetch the thumbnail only when the job identity changed.
+            // Identity is the upstream PrusaLink `id` when both sides have
+            // one (so a reprint of the same file gets a fresh thumbnail even
+            // though the displayName matches -- issue #20); otherwise falls
+            // back to the displayName.
+            let isSame = Self.isSameJob(lhs: previous, rhs: job)
             model.lastJob = job
-            if !isSameFile {
+            if !isSame {
                 model.lastThumbnail = nil
                 if let path = job.thumbnailPath {
                     let thumbResult = await client.fetchThumbnail(at: path)
-                    if case let .success(data) = thumbResult {
+                    // The await yields the main actor; a faster poll cycle can
+                    // have installed a new lastJob while we were fetching.
+                    // Drop the bytes when that happens so the stale fetch does
+                    // not overwrite the newer thumbnail.
+                    let stillCurrent = Self.isSameJob(lhs: model.lastJob, rhs: job)
+                    if case let .success(data) = thumbResult, stillCurrent {
                         model.lastThumbnail = data
                     }
                 }
             }
         case let .failure(error):
             Log.polling.notice("Job fetch failed (non-fatal): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Whether two `PrintJob` values describe the same print. Prefers the
+    /// upstream PrusaLink `id` when both sides have one; otherwise falls back
+    /// to `displayName` for firmware that does not surface an id.
+    /// `nonisolated static` so the identity rule is unit-testable without
+    /// standing up a coordinator.
+    nonisolated static func isSameJob(lhs: PrintJob?, rhs: PrintJob?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil):
+            return true
+        case let (l?, r?):
+            if let lid = l.id, let rid = r.id { return lid == rid }
+            return l.displayName == r.displayName
+        default:
+            return false
         }
     }
 

--- a/PrusaStatusBar/UI/Components/CameraPlayer.swift
+++ b/PrusaStatusBar/UI/Components/CameraPlayer.swift
@@ -57,9 +57,18 @@
         private var loadedURL: URL?
         private var statusObservation: NSKeyValueObservation?
         private var presentationSizeObservation: NSKeyValueObservation?
+        private var timeControlObservation: NSKeyValueObservation?
         private var lastReportedPresentationSize: CGSize = .zero
         private var retryAttempt: Int = 0
         private var pendingRetry: Task<Void, Never>?
+        private var stallRecoveryTask: Task<Void, Never>?
+
+        /// Maximum time AVPlayer is allowed to dwell in
+        /// `.waitingToPlayAtSpecifiedRate` before we treat the HLS
+        /// pipeline as stalled and rebuild the player. Covers the cold
+        /// go2rtc warm-up window (3-5s) and the longest Buddy keyframe
+        /// interval seen on MK4-class printers (~5-7s) with margin.
+        private let stallRecoveryDelay: TimeInterval = 8.0
 
         /// Invoked once the retry budget exhausts without `.readyToPlay`.
         /// Used by `GenericCameraTile` to fall back to still-image polling.
@@ -123,10 +132,14 @@
         func tearDown() {
             pendingRetry?.cancel()
             pendingRetry = nil
+            stallRecoveryTask?.cancel()
+            stallRecoveryTask = nil
             statusObservation?.invalidate()
             statusObservation = nil
             presentationSizeObservation?.invalidate()
             presentationSizeObservation = nil
+            timeControlObservation?.invalidate()
+            timeControlObservation = nil
             lastReportedPresentationSize = .zero
             player?.pause()
             playerLayer.player = nil
@@ -143,6 +156,10 @@
             statusObservation = nil
             presentationSizeObservation?.invalidate()
             presentationSizeObservation = nil
+            timeControlObservation?.invalidate()
+            timeControlObservation = nil
+            stallRecoveryTask?.cancel()
+            stallRecoveryTask = nil
             let item = AVPlayerItem(url: url)
             let player = AVPlayer(playerItem: item)
             player.isMuted = true
@@ -169,6 +186,22 @@
                 }
             }
 
+            // AVPlayer can park in `.waitingToPlayAtSpecifiedRate` without
+            // ever flipping the item to `.failed` when go2rtc serves a
+            // sparse HLS playlist (e.g. one segment with a long Buddy
+            // keyframe interval). The status observer above only catches
+            // the explicit-failure path, so a silent stall would leave
+            // the tile frozen on its first decoded frame indefinitely.
+            // Watch `timeControlStatus` and rebuild the player if the
+            // waiting state persists past `stallRecoveryDelay`.
+            timeControlObservation = player
+                .observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
+                    let status = player.timeControlStatus
+                    Task { @MainActor in
+                        self?.handle(timeControl: status)
+                    }
+                }
+
             player.play()
         }
 
@@ -192,6 +225,28 @@
                 break
             @unknown default:
                 break
+            }
+        }
+
+        /// Schedules a silent player rebuild when AVPlayer parks in
+        /// `.waitingToPlayAtSpecifiedRate` for longer than
+        /// `stallRecoveryDelay`. Cancels itself the moment the player
+        /// resumes playback (`.playing`) or the user pauses it
+        /// (`.paused`). Reuses `installPlayer(url:)` so the recovery path
+        /// matches what `scheduleRetry` does for explicit failures.
+        @MainActor
+        private func handle(timeControl: AVPlayer.TimeControlStatus) {
+            stallRecoveryTask?.cancel()
+            stallRecoveryTask = nil
+            guard timeControl == .waitingToPlayAtSpecifiedRate else { return }
+            guard let url = loadedURL else { return }
+            let delayNanos = UInt64(stallRecoveryDelay * 1_000_000_000)
+            stallRecoveryTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: delayNanos)
+                guard let self, !Task.isCancelled else { return }
+                guard loadedURL == url else { return }
+                guard player?.timeControlStatus == .waitingToPlayAtSpecifiedRate else { return }
+                installPlayer(url: url)
             }
         }
 

--- a/PrusaStatusBar/UI/Components/DropdownContentHeightReporter.swift
+++ b/PrusaStatusBar/UI/Components/DropdownContentHeightReporter.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// Carries the rendered `DropdownView` content height up the view tree so
+/// the detached-window path can re-fit its `NSWindow` when the height
+/// changes (issue #19). A single `GeometryReader` writes it, so `reduce`
+/// just keeps the latest non-zero value. Mirrors `CameraTileHeightPreference`.
+private struct DropdownContentHeightPreference: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        let next = nextValue()
+        if next > 0 { value = next }
+    }
+}
+
+/// Measures the modified view's height and invokes `onChange` whenever it
+/// changes. A VStack of fixed-size children overflows (rather than clips)
+/// when its host window is too short, so the measured height is the true
+/// intrinsic content height -- exactly what the detached window needs to
+/// re-fit against.
+private struct DropdownContentHeightReporter: ViewModifier {
+    let onChange: @MainActor () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: DropdownContentHeightPreference.self,
+                        value: proxy.size.height
+                    )
+                }
+            }
+            .onPreferenceChange(DropdownContentHeightPreference.self) { _ in
+                // Fire on the next main-actor tick so the re-fit runs after
+                // the current SwiftUI update completes (no re-entrant
+                // setFrame).
+                Task { @MainActor in onChange() }
+            }
+    }
+}
+
+extension View {
+    /// Reports this view's rendered height, invoking `onChange` on every
+    /// height change. See `DropdownContentHeightReporter`.
+    func reportingContentHeight(onChange: @escaping @MainActor () -> Void) -> some View {
+        modifier(DropdownContentHeightReporter(onChange: onChange))
+    }
+}

--- a/PrusaStatusBar/UI/DetachedStatusWindowController.swift
+++ b/PrusaStatusBar/UI/DetachedStatusWindowController.swift
@@ -11,6 +11,10 @@ import SwiftUI
 /// front. The frame is NOT autosaved: every detach centers on the active
 /// screen and sizes height to current content via a few timed
 /// `sizeThatFits` polls (cheap, one-way, no layout loop).
+///
+/// `refit()` re-runs that same poll while the window stays open, so the
+/// window tracks content-height changes (e.g. a print finishing then a new
+/// print starting) instead of freezing at its open-time height -- issue #19.
 @MainActor
 final class DetachedStatusWindowController: NSObject, NSWindowDelegate {
     private let onShow: () -> Void
@@ -71,6 +75,18 @@ final class DetachedStatusWindowController: NSObject, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    /// Re-fit the open detached window to the current `DropdownView`
+    /// content height. Invoked when the content reports a height change
+    /// (e.g. a print finishing then a new print starting -- issue #19).
+    /// Safe no-op when no window is open. Re-uses the one-way
+    /// `fitWindowToContent` poll, so it cannot start a layout loop:
+    /// `sizeThatFits` is measured against a fixed box and is independent of
+    /// the window's own height, so our `setFrame` never feeds back in.
+    func refit() {
+        guard let host else { return }
+        fitWindowToContent(hosting: host)
+    }
+
     func windowWillClose(_ notification: Notification) {
         guard (notification.object as? NSWindow) === window else { return }
         sizingTask?.cancel()
@@ -98,15 +114,34 @@ final class DetachedStatusWindowController: NSObject, NSWindowDelegate {
                 let fitted = hosting.sizeThatFits(in: NSSize(width: 360, height: 10000))
                 guard fitted.height > 50 else { continue }
                 let maxH = (w.screen?.visibleFrame.height ?? NSScreen.main?.visibleFrame.height ?? 900) - 100
-                let height = min(fitted.height, maxH)
-                if abs(w.frame.height - height) > 0.5 {
-                    var frame = w.frame
-                    frame.origin.y += frame.height - height
-                    frame.size.height = height
+                if let frame = Self.refittedFrame(
+                    current: w.frame,
+                    fittedHeight: fitted.height,
+                    maxHeight: maxH
+                ) {
                     w.setFrame(frame, display: true, animate: false)
                 }
             }
             self?.sizingTask = nil
         }
+    }
+
+    /// Computes the re-fitted window frame for a freshly measured content
+    /// height. Keeps the window's top edge anchored (the window grows or
+    /// shrinks downward), clamps the height to `maxHeight`, and returns
+    /// `nil` when the resulting height is within 0.5 pt of the current
+    /// frame -- no resize worth a layout pass. Pure + `nonisolated` so the
+    /// height math is unit-testable without standing up an `NSWindow`.
+    nonisolated static func refittedFrame(
+        current: NSRect,
+        fittedHeight: CGFloat,
+        maxHeight: CGFloat
+    ) -> NSRect? {
+        let height = min(fittedHeight, maxHeight)
+        guard abs(current.height - height) > 0.5 else { return nil }
+        var frame = current
+        frame.origin.y += frame.height - height
+        frame.size.height = height
+        return frame
     }
 }

--- a/PrusaStatusBar/UI/DropdownView.swift
+++ b/PrusaStatusBar/UI/DropdownView.swift
@@ -38,6 +38,15 @@ struct DropdownView: View {
     /// circular detach).
     var onDetach: (() -> Void)?
 
+    /// Invoked when the rendered content height changes. `MenuBarController`
+    /// wires this only for the detached window, where it drives
+    /// `DetachedStatusWindowController.refit()` so the floating window
+    /// tracks content-height changes instead of freezing at its open-time
+    /// height (issue #19). The no-op default keeps the popover path -- which
+    /// already auto-sizes via `NSHostingController.sizingOptions` -- and
+    /// SwiftUI previews free of window plumbing.
+    var onContentResize: @MainActor () -> Void = {}
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State var customActionFeedback: [CustomActionSlot: CustomActionFeedback] = [:]
 
@@ -98,6 +107,10 @@ struct DropdownView: View {
             alignment: .topLeading
         )
         .background(.regularMaterial)
+        // Bubble the rendered content height up so the detached window can
+        // re-fit when a print transition changes it (issue #19). No-op for
+        // the popover, which auto-sizes via `sizingOptions`.
+        .reportingContentHeight(onChange: onContentResize)
         .environment(\.brandAccent, model.accent)
         .environment(\.brandCustomHex, model.customAccentHex)
         .animation(

--- a/PrusaStatusBar/UI/MenuBarController+Popover.swift
+++ b/PrusaStatusBar/UI/MenuBarController+Popover.swift
@@ -4,8 +4,14 @@ import SwiftUI
 extension MenuBarController {
     /// Builds a fully wired `DropdownView`. Pass `onDetach` to show the
     /// "Detach" footer button (popover context); pass `nil` to hide it
-    /// (detached window context, where nesting would be circular).
-    func makeDropdownView(onDetach: (() -> Void)? = nil) -> DropdownView {
+    /// (detached window context, where nesting would be circular). Pass
+    /// `onContentResize` for the detached window so it re-fits when the
+    /// content height changes (issue #19); the popover leaves the no-op
+    /// default since it auto-sizes via `NSHostingController.sizingOptions`.
+    func makeDropdownView(
+        onDetach: (() -> Void)? = nil,
+        onContentResize: @escaping @MainActor () -> Void = {}
+    ) -> DropdownView {
         var view = DropdownView(
             model: model,
             onRefresh: { [weak self] in self?.coordinator.refreshNow() },
@@ -27,6 +33,7 @@ extension MenuBarController {
             self?.cameraQuickLook.open(kind: kind, source: source)
         }
         view.onDetach = onDetach
+        view.onContentResize = onContentResize
         return view
     }
 

--- a/PrusaStatusBar/UI/MenuBarController.swift
+++ b/PrusaStatusBar/UI/MenuBarController.swift
@@ -326,7 +326,12 @@ public final class MenuBarController {
         // handlePopoverDidClose Task sees it and skips clearing popoverVisible.
         model.detachedWindowVisible = true
         popover.performClose(nil)
-        detachedWindowController.present(view: makeDropdownView(onDetach: nil))
+        detachedWindowController.present(
+            view: makeDropdownView(
+                onDetach: nil,
+                onContentResize: { [weak self] in self?.detachedWindowController.refit() }
+            )
+        )
     }
 }
 

--- a/PrusaStatusBarTests/DetachedStatusWindowControllerTests.swift
+++ b/PrusaStatusBarTests/DetachedStatusWindowControllerTests.swift
@@ -1,0 +1,87 @@
+import AppKit
+@testable import PrusaStatusBar
+import Testing
+
+/// Spec coverage:
+/// - `menu-bar-ui` Requirement: Detached window re-fits to content height
+///   changes
+///   - Scenario "New print starts while detached window is open"
+///   - Scenario "Content shrinks while detached window is open"
+///   - Scenario "Re-fit keeps the top edge anchored"
+///   - Scenario "Re-fit caps height to the visible screen"
+struct DetachedStatusWindowControllerTests {
+    /// New print -> taller content: the window grows downward while its top
+    /// edge (`maxY`, since macOS frames are bottom-left origin) stays put.
+    @Test
+    func refitGrowsWindowDownwardKeepingTopAnchored() throws {
+        let current = NSRect(x: 100, y: 500, width: 360, height: 400)
+
+        let frame = try #require(
+            DetachedStatusWindowController.refittedFrame(
+                current: current,
+                fittedHeight: 480,
+                maxHeight: 900
+            )
+        )
+
+        #expect(frame.size.height == 480)
+        #expect(frame.size.width == current.size.width)
+        #expect(frame.maxY == current.maxY) // top edge anchored
+        #expect(frame.minY < current.minY) // grew downward
+    }
+
+    /// Printer returns to idle -> shorter content: the window shrinks from
+    /// the bottom, top edge still anchored.
+    @Test
+    func refitShrinksWindowKeepingTopAnchored() throws {
+        let current = NSRect(x: 100, y: 500, width: 360, height: 400)
+
+        let frame = try #require(
+            DetachedStatusWindowController.refittedFrame(
+                current: current,
+                fittedHeight: 250,
+                maxHeight: 900
+            )
+        )
+
+        #expect(frame.size.height == 250)
+        #expect(frame.maxY == current.maxY) // top edge anchored
+        #expect(frame.minY > current.minY) // shrank from the bottom
+    }
+
+    /// Content taller than the visible screen is clamped to `maxHeight`.
+    @Test
+    func refitClampsHeightToMax() {
+        let current = NSRect(x: 0, y: 0, width: 360, height: 400)
+
+        let result = DetachedStatusWindowController.refittedFrame(
+            current: current,
+            fittedHeight: 2000,
+            maxHeight: 700
+        )
+
+        #expect(result?.size.height == 700)
+    }
+
+    /// A sub-0.5 pt height delta is not worth a resize: returns nil so the
+    /// caller skips `setFrame`.
+    @Test
+    func refitReturnsNilForNegligibleDelta() {
+        let current = NSRect(x: 0, y: 0, width: 360, height: 400)
+
+        #expect(
+            DetachedStatusWindowController.refittedFrame(
+                current: current,
+                fittedHeight: 400.3,
+                maxHeight: 900
+            ) == nil
+        )
+        #expect(
+            DetachedStatusWindowController.refittedFrame(
+                current: current,
+                fittedHeight: 400,
+                maxHeight: 900
+            ) == nil
+        )
+    }
+}

--- a/PrusaStatusBarTests/GoRTCServiceLifecycleTests.swift
+++ b/PrusaStatusBarTests/GoRTCServiceLifecycleTests.swift
@@ -75,6 +75,38 @@ struct GoRTCServiceLifecycleTests {
         #expect(isProcessAlive(pid) == true)
     }
 
+    /// Regression for the issue #20 follow-up freeze: a Buddy notification
+    /// snapshot captured while the live dropdown tile is streaming must
+    /// not restart the go2rtc helper. The bug was that the live tile
+    /// registered `rtsp://...#transport=tcp` while the snapshot path
+    /// registered the raw `rtsp://...`, so `applyStreams` saw two distinct
+    /// `streams:` dicts and tore the helper down at every print state
+    /// transition. AVPlayer's HLS endpoint URL did not change, so SwiftUI
+    /// never re-attached, and the tile froze on the last frame until the
+    /// user closed and reopened the dropdown.
+    @Test
+    func buddySnapshotDoesNotRestartHelperWhenLiveTileIsRunning() async throws {
+        let (service, paths) = makeService(matchSleep: true)
+        defer { try? FileManager.default.removeItem(at: paths.tmpDir) }
+
+        // Live tile spins up the helper with `#transport=tcp` appended.
+        let hlsURL = service.hlsURL(forRTSP: "rtsp://example/test")
+        #expect(hlsURL != nil)
+        let livePID = try readPID(at: paths.pidFileURL)
+
+        // Snapshot path now routes through the canonical Buddy entry. With
+        // an unreachable helper port the call times out at the API-readiness
+        // probe, which is exactly the assertion surface we want: the failure
+        // mode does NOT include restarting the helper subprocess.
+        _ = try? await service.snapshotBuddyJPEG(
+            rtspURL: "rtsp://example/test",
+            timeout: 0.2
+        )
+
+        let afterPID = try readPID(at: paths.pidFileURL)
+        #expect(afterPID == livePID, "snapshot must not restart helper while live tile is mounted")
+    }
+
     @Test
     func reapStaleHelperWithNoPIDFileIsNoOp() {
         let (service, paths) = makeService(matchSleep: true)
@@ -149,5 +181,14 @@ struct GoRTCServiceLifecycleTests {
     private func isProcessAlive(_ pid: pid_t) -> Bool {
         if Darwin.kill(pid, 0) == 0 { return true }
         return errno != ESRCH
+    }
+
+    private func readPID(at url: URL) throws -> pid_t {
+        let raw = try String(contentsOf: url, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let pid = pid_t(raw) else {
+            throw POSIXError(.ESRCH)
+        }
+        return pid
     }
 }

--- a/PrusaStatusBarTests/PollingCoordinatorJobIdentityTests.swift
+++ b/PrusaStatusBarTests/PollingCoordinatorJobIdentityTests.swift
@@ -1,0 +1,66 @@
+@testable import PrusaStatusBar
+import Testing
+
+/// Spec coverage:
+/// - `polling` Requirement: Job detail and thumbnail refresh on job
+///   identity change
+///   - Scenario "Same job across polls"
+///   - Scenario "Reprint of the same file gets a fresh thumbnail"
+///   - Scenario "New file starts printing"
+struct PollingCoordinatorJobIdentityTests {
+    @Test
+    func bothIdsEqualIsSameJob() {
+        let a = PrintJob(displayName: "model.bgcode", id: 42)
+        let b = PrintJob(displayName: "model.bgcode", id: 42)
+        #expect(PollingCoordinator.isSameJob(lhs: a, rhs: b))
+    }
+
+    /// Regression guard for issue #20: a reprint reuses the file name but
+    /// gets a new upstream `id`, so the identity check MUST return false so
+    /// the thumbnail is refetched.
+    @Test
+    func differentIdsIsNotSameJobEvenWhenNameMatches() {
+        let a = PrintJob(displayName: "model.bgcode", id: 42)
+        let b = PrintJob(displayName: "model.bgcode", id: 43)
+        #expect(!PollingCoordinator.isSameJob(lhs: a, rhs: b))
+    }
+
+    @Test
+    func nilIdsFallBackToDisplayNameMatch() {
+        let a = PrintJob(displayName: "model.bgcode", id: nil)
+        let b = PrintJob(displayName: "model.bgcode", id: nil)
+        #expect(PollingCoordinator.isSameJob(lhs: a, rhs: b))
+    }
+
+    @Test
+    func nilIdsFallBackToDisplayNameMismatch() {
+        let a = PrintJob(displayName: "first.bgcode", id: nil)
+        let b = PrintJob(displayName: "second.bgcode", id: nil)
+        #expect(!PollingCoordinator.isSameJob(lhs: a, rhs: b))
+    }
+
+    /// Mixed-nullability `id`s fall back to the `displayName` check so
+    /// older PrusaLink firmware (which may omit `id` on one side of a
+    /// transition) behaves as it did before the fix.
+    @Test
+    func mixedIdNullabilityFallsBackToDisplayName() {
+        let withID = PrintJob(displayName: "model.bgcode", id: 42)
+        let withoutID = PrintJob(displayName: "model.bgcode", id: nil)
+        #expect(PollingCoordinator.isSameJob(lhs: withID, rhs: withoutID))
+
+        let withIDOther = PrintJob(displayName: "other.bgcode", id: 42)
+        #expect(!PollingCoordinator.isSameJob(lhs: withIDOther, rhs: withoutID))
+    }
+
+    @Test
+    func bothNilIsSameJob() {
+        #expect(PollingCoordinator.isSameJob(lhs: nil, rhs: nil))
+    }
+
+    @Test
+    func oneNilIsNotSameJob() {
+        let a = PrintJob(displayName: "model.bgcode", id: 42)
+        #expect(!PollingCoordinator.isSameJob(lhs: a, rhs: nil))
+        #expect(!PollingCoordinator.isSameJob(lhs: nil, rhs: a))
+    }
+}


### PR DESCRIPTION
<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

Refresh image issues on consecutive prints

## Checklist

- [x] Tests added or updated (Swift Testing).
- [x] `just check` passes locally.
- [x] `just test` passes locally.
- [x] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [x]  No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Fix detached status window and job thumbnail refresh issues when consecutive prints or job identity changes occur.

Bug Fixes:
- Ensure the detached status window resizes to track content height changes while open, keeping its top edge anchored and respecting screen limits.
- Refresh job details and thumbnails whenever the underlying print job identity changes, including reprints of the same file, and avoid applying stale thumbnails from slower fetches.

Enhancements:
- Introduce reusable helpers for computing refitted window frames and comparing print job identity to support unit testing and clearer refresh logic.

Tests:
- Add unit tests covering detached window refitting behavior for growing, shrinking, clamped heights, and negligible changes.
- Add unit tests defining and validating print job identity rules across id and display name combinations.