### PR TITLE
feat: add url and ip/hostname validation on printer and webcam setup #23

### DIFF
--- a/PrusaStatusBar.xcodeproj/project.pbxproj
+++ b/PrusaStatusBar.xcodeproj/project.pbxproj
@@ -42,11 +42,13 @@
 		34F3A65CEE3C99CA3B708E50 /* PrinterTestResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42FFE203D711955564DC0FD /* PrinterTestResult.swift */; };
 		35975DB57C0F2315DB960E6F /* ProgressBarStylePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9F490F5BC72EDF7C8E42D82 /* ProgressBarStylePreview.swift */; };
 		35FE62554F2D7E0B5C141A87 /* JobBackdropRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51B037059349E8C2151A0F30 /* JobBackdropRenderer.swift */; };
+		360539A7C9FD2F0CD8C9C239 /* FieldValidationCaption.swift in Sources */ = {isa = PBXBuildFile; fileRef = E98BC8C8787FF5C5A879E043 /* FieldValidationCaption.swift */; };
 		37B645A9E57F74D3865BE7E5 /* CustomActionsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCD03C88656C9307469ABB62 /* CustomActionsRow.swift */; };
 		385D0171E159EFFFDFFAF0BE /* HeroHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4F5D13FCC5216930FC64DE7 /* HeroHeader.swift */; };
 		394CD875B62CAC03465FC1CE /* PrusaStatusBarApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B0400EE85F3DABF3548727 /* PrusaStatusBarApp.swift */; };
 		3C4491E9C35F124A20ADFFF2 /* AnimatedPrintingIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0C5D4129FE0B5FF7590C98 /* AnimatedPrintingIconView.swift */; };
 		3C735DAC8253D833E1F2B341 /* DropdownJobCardVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A132036C7DED65BA4492AA41 /* DropdownJobCardVisibilityTests.swift */; };
+		406805AAB4ED041E734E37B3 /* URLHostValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A047474263C8051324C2145 /* URLHostValidator.swift */; };
 		42AAA9655AAFBD70431775E3 /* MenuBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D554A0FAD2745ECF1E08D92 /* MenuBarController.swift */; };
 		440DE2074B248D3198CF57A9 /* PollingCoordinator+Started.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0561CD4C3F3F048B786A8D6B /* PollingCoordinator+Started.swift */; };
 		443B0277987E3536A95B47BD /* GenericCameraTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E99728B719D56AFD4AD215 /* GenericCameraTile.swift */; };
@@ -137,6 +139,7 @@
 		AAECD8F8B5FEAD6DDDABD5C3 /* CustomActionHeadersEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F1A5B6EB0E5935430805A8 /* CustomActionHeadersEditor.swift */; };
 		ADB0C7E9F133CCDF2809B11C /* DropdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92321F45A3CC1E75D6D9CDB /* DropdownView.swift */; };
 		AE31B64BFF1C64B16BE15BBB /* GoRTCServiceLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B99AD4E2AC6EFDC7A550D5B /* GoRTCServiceLifecycleTests.swift */; };
+		B02A47E4C2A239E6B714B088 /* PrinterBaseURLValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB03CDE6299245F9832F91C /* PrinterBaseURLValidator.swift */; };
 		B08ACC78F5282362D303B6ED /* KeychainToggleConfirmationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED036D96CCA8731010B0E08 /* KeychainToggleConfirmationTests.swift */; };
 		B09EDD67EB0806675A154C0F /* FooterBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE76CF22C0FD564C030BFF6 /* FooterBar.swift */; };
 		B5C1FFE030E3C8981CC923A2 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47070FEC5E436443EFBE7A65 /* NotificationService.swift */; };
@@ -161,6 +164,7 @@
 		CCDBE7B121A619774A749152 /* RTSPProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650D002FB5F5CCB2FE73F06A /* RTSPProbe.swift */; };
 		CF5BED69B30E01A19FE8DE07 /* CustomActionSlotCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E47401C33A9E6885BFF765E0 /* CustomActionSlotCard.swift */; };
 		CFFAD20742A23788FCCDB4E9 /* CustomActionIconButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6366359FCD5B87ADEF304FA3 /* CustomActionIconButton.swift */; };
+		D1A1E47B0D8ADA00CD560AFC /* PrinterBaseURLValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D192C2F790D169C82B974C4B /* PrinterBaseURLValidatorTests.swift */; };
 		D1E49AFE35A4774F0299D1CA /* RTSPURLValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C879DC896D45F7CF9A704 /* RTSPURLValidator.swift */; };
 		D2CC8BA3A6CD70DE9048A37F /* StubLoginItemServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E012958219D387974AE1ED2E /* StubLoginItemServiceTests.swift */; };
 		D4C34F96438E472C7D50BAFA /* UserPreferences+StartedNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13ED48F8B7892A0CF720795 /* UserPreferences+StartedNotification.swift */; };
@@ -229,11 +233,13 @@
 		29FC7C5C0CFCF94A4E92B36F /* SpoolIntervalSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpoolIntervalSlider.swift; sourceTree = "<group>"; };
 		2A276E376DB552076E757B40 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		2B709BD4961212641C513D09 /* AccentSwatchPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccentSwatchPicker.swift; sourceTree = "<group>"; };
+		2BB03CDE6299245F9832F91C /* PrinterBaseURLValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterBaseURLValidator.swift; sourceTree = "<group>"; };
 		2C8D9A3CCF6D918250AB3BE1 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2FD037E5150F9CA0B3C2772E /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		30E3FC2A623E22E09E74C73A /* PollingCoordinatorBurstTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollingCoordinatorBurstTokenTests.swift; sourceTree = "<group>"; };
 		36E204C53CE2ED7354076CFF /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		38F5D3957E585AF16DD2F2AD /* GenericCameraConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericCameraConfig.swift; sourceTree = "<group>"; };
+		3A047474263C8051324C2145 /* URLHostValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHostValidator.swift; sourceTree = "<group>"; };
 		3A92450A04D5403D2785BD17 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3BDF6247719EB661D35E2F75 /* ProgressBarPremium.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarPremium.swift; sourceTree = "<group>"; };
 		3D7CF1047D4B69AB79344E6C /* CustomActionConfirmDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionConfirmDialog.swift; sourceTree = "<group>"; };
@@ -349,6 +355,7 @@
 		CE586F52EE91EB854CC28633 /* PrusaLinkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrusaLinkClient.swift; sourceTree = "<group>"; };
 		CED036D96CCA8731010B0E08 /* KeychainToggleConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainToggleConfirmationTests.swift; sourceTree = "<group>"; };
 		CEF1B13D41324CC3F77689D4 /* UserPreferencesGenericCameraTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPreferencesGenericCameraTests.swift; sourceTree = "<group>"; };
+		D192C2F790D169C82B974C4B /* PrinterBaseURLValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterBaseURLValidatorTests.swift; sourceTree = "<group>"; };
 		D1CEA6F5D7BD2C8B5C2659B4 /* PollingCoordinator+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PollingCoordinator+Notifications.swift"; sourceTree = "<group>"; };
 		D56E480080DDB6D31572A308 /* PrinterTab+Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrinterTab+Keychain.swift"; sourceTree = "<group>"; };
 		D5E3A827E5B85503CE799041 /* DropdownView+CustomActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DropdownView+CustomActions.swift"; sourceTree = "<group>"; };
@@ -368,6 +375,7 @@
 		E62E0CC8CC98F27EEEEF87FB /* CameraTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraTile.swift; sourceTree = "<group>"; };
 		E6C69573362E773CF8621112 /* GenericCameraSection+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericCameraSection+Test.swift"; sourceTree = "<group>"; };
 		E9837A8DDC769BBEC409ECB0 /* GenericCameraURLValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericCameraURLValidatorTests.swift; sourceTree = "<group>"; };
+		E98BC8C8787FF5C5A879E043 /* FieldValidationCaption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldValidationCaption.swift; sourceTree = "<group>"; };
 		EA270CAFE1C767224C955D2B /* PrusaLinkResponseDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrusaLinkResponseDecoding.swift; sourceTree = "<group>"; };
 		EC7D035DB58E2A9E6B28BC72 /* FormCaptionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormCaptionRow.swift; sourceTree = "<group>"; };
 		EE2D13503C945185A91E351C /* StatusPresenterDisconnectedIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPresenterDisconnectedIconTests.swift; sourceTree = "<group>"; };
@@ -403,6 +411,7 @@
 				E47401C33A9E6885BFF765E0 /* CustomActionSlotCard.swift */,
 				DCD03C88656C9307469ABB62 /* CustomActionsRow.swift */,
 				5F74880505D4E63902C3FBF7 /* DisconnectedIconStylePicker.swift */,
+				E98BC8C8787FF5C5A879E043 /* FieldValidationCaption.swift */,
 				DFE76CF22C0FD564C030BFF6 /* FooterBar.swift */,
 				EC7D035DB58E2A9E6B28BC72 /* FormCaptionRow.swift */,
 				984D779F250A0BC8970F2AD8 /* GenericCameraCards.swift */,
@@ -464,6 +473,7 @@
 				3F6300AAF35702526B92279B /* PollingCoordinator.swift */,
 				D1CEA6F5D7BD2C8B5C2659B4 /* PollingCoordinator+Notifications.swift */,
 				0561CD4C3F3F048B786A8D6B /* PollingCoordinator+Started.swift */,
+				2BB03CDE6299245F9832F91C /* PrinterBaseURLValidator.swift */,
 				CE586F52EE91EB854CC28633 /* PrusaLinkClient.swift */,
 				EA270CAFE1C767224C955D2B /* PrusaLinkResponseDecoding.swift */,
 				650D002FB5F5CCB2FE73F06A /* RTSPProbe.swift */,
@@ -474,6 +484,7 @@
 				061D5B0EC2EE762EC7D57CB7 /* StubGitHubReleaseClient.swift */,
 				24727A401168DE8D4E947F00 /* StubPrusaLinkClient.swift */,
 				B7C145F93387C418D7650EC7 /* UpdateChecker.swift */,
+				3A047474263C8051324C2145 /* URLHostValidator.swift */,
 				76A28666046C15B3988ED729 /* URLSessionGitHubReleaseClient.swift */,
 				29DBFFE12DA3580F371C929B /* URLSessionPrusaLinkClient.swift */,
 				4526FE5ADC7EA3CB56022219 /* UserPreferences.swift */,
@@ -596,6 +607,7 @@
 				30E3FC2A623E22E09E74C73A /* PollingCoordinatorBurstTokenTests.swift */,
 				01E6CDDD0D76BB029B8825B7 /* PollingCoordinatorIntervalTests.swift */,
 				40820872A7703EB26D27F4E6 /* PopoverLifecycleTests.swift */,
+				D192C2F790D169C82B974C4B /* PrinterBaseURLValidatorTests.swift */,
 				5587386878C425BB00FB8A88 /* PrinterStateTests.swift */,
 				8892FCD27EA15ADC1D87DD6B /* PrintingIconAnimatorTests.swift */,
 				917FAD85518D848DBF7AF41F /* PrusaLinkErrorMappingTests.swift */,
@@ -818,6 +830,7 @@
 				4B8C3CDD6FD50821F23176BF /* PollingCoordinatorBurstTokenTests.swift in Sources */,
 				8BD0D270D5E8F2A37C5C3C08 /* PollingCoordinatorIntervalTests.swift in Sources */,
 				34D25079A797278C3DFD579A /* PopoverLifecycleTests.swift in Sources */,
+				D1A1E47B0D8ADA00CD560AFC /* PrinterBaseURLValidatorTests.swift in Sources */,
 				E534F68B76F0FC7AF72C2F9C /* PrinterStateTests.swift in Sources */,
 				7844465B9AFE738EF4B0306D /* PrintingIconAnimatorTests.swift in Sources */,
 				69DB2C0ED8197DCF219CE716 /* PrusaLinkErrorMappingTests.swift in Sources */,
@@ -882,6 +895,7 @@
 				A572439161C5663B19496F00 /* DisconnectedIconStylePicker.swift in Sources */,
 				86B855EEA0F810E156D4B2B6 /* DropdownView+CustomActions.swift in Sources */,
 				ADB0C7E9F133CCDF2809B11C /* DropdownView.swift in Sources */,
+				360539A7C9FD2F0CD8C9C239 /* FieldValidationCaption.swift in Sources */,
 				B09EDD67EB0806675A154C0F /* FooterBar.swift in Sources */,
 				DBDBC497E4EBD6F4D5BE2431 /* FormCaptionRow.swift in Sources */,
 				1126B362A751DFC125C8B18E /* GeneralTab.swift in Sources */,
@@ -924,6 +938,7 @@
 				440DE2074B248D3198CF57A9 /* PollingCoordinator+Started.swift in Sources */,
 				E5F9C834C002FDA2B6356DBD /* PollingCoordinator.swift in Sources */,
 				9892F61C7B50D5C7750441C4 /* PreferencesWindow.swift in Sources */,
+				B02A47E4C2A239E6B714B088 /* PrinterBaseURLValidator.swift in Sources */,
 				A830BC1C0BBF81CCFA125484 /* PrinterKeychainConfirmation.swift in Sources */,
 				B6DC0419AD06204E8E265296 /* PrinterNotificationHintSection.swift in Sources */,
 				5CE3B29D074AE5B898FE1E73 /* PrinterState.swift in Sources */,
@@ -957,6 +972,7 @@
 				561CE20656D508E55D068C53 /* SymbolPickerSheet.swift in Sources */,
 				BF4529BD4AAC0D9124205D56 /* TempCard.swift in Sources */,
 				BAFFA0C477089A0535556F0C /* Theme.swift in Sources */,
+				406805AAB4ED041E734E37B3 /* URLHostValidator.swift in Sources */,
 				610A9FB1B5749026AD783535 /* URLSessionGitHubReleaseClient.swift in Sources */,
 				121DB9311EA05DC2B4920D69 /* URLSessionPrusaLinkClient.swift in Sources */,
 				1DAD26FD77459279800E2B94 /* UnconfiguredCard.swift in Sources */,

--- a/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "Skrýt API klíč";
 "printer.field.display_name"              = "Zobrazované jméno";
 "printer.url.test_help"                   = "Otestovat tuto URL";
+"printer.field.validation.valid"          = "Platná URL";
+"printer.field.validation.valid_host"     = "Platná IP nebo název hostitele";
+"printer.field.validation.invalid_url"    = "Neplatná URL";
+"printer.field.validation.invalid_host"   = "Zadejte platnou IP nebo název hostitele";
+"printer.field.validation.click_to_test"  = "Klikněte na ikonu pro ověření připojení";
 "common.help.tooltip"                     = "Více informací";
 "common.help.learn_more"                  = "Zjistit více";
 "printer.help.url.body"                   = "Zadejte http://<ip> nebo http://<hostname> své tiskárny (například http://192.168.1.42 nebo http://prusa-mk3.local). Nejprve adresu otevřete ve webovém prohlížeči a ověřte, že se PrusaLink načte.";

--- a/PrusaStatusBar/Resources/de.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/de.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "API-Schlüssel ausblenden";
 "printer.field.display_name"              = "Anzeigename";
 "printer.url.test_help"                   = "Diese URL testen";
+"printer.field.validation.valid"          = "Gültige URL";
+"printer.field.validation.valid_host"     = "Gültige IP oder Hostname";
+"printer.field.validation.invalid_url"    = "Ungültige URL";
+"printer.field.validation.invalid_host"   = "Gültige IP oder Hostname eingeben";
+"printer.field.validation.click_to_test"  = "Auf das Symbol klicken, um die Verbindung zu prüfen";
 "common.help.tooltip"                     = "Mehr Infos";
 "common.help.learn_more"                  = "Mehr erfahren";
 "printer.help.url.body"                   = "Geben Sie http://<ip> oder http://<hostname> Ihres Druckers ein (zum Beispiel http://192.168.1.42 oder http://prusa-mk3.local). Öffnen Sie die Adresse zuerst in Ihrem Webbrowser, um sicherzustellen, dass PrusaLink geladen wird.";

--- a/PrusaStatusBar/Resources/en.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/en.lproj/Localizable.strings
@@ -81,6 +81,11 @@
 "printer.api_key.hide"                    = "Hide API key";
 "printer.field.display_name"              = "Display name";
 "printer.url.test_help"                   = "Test this URL";
+"printer.field.validation.valid"          = "Valid URL";
+"printer.field.validation.valid_host"     = "Valid IP or hostname";
+"printer.field.validation.invalid_url"    = "Invalid URL";
+"printer.field.validation.invalid_host"   = "Enter a valid IP or hostname";
+"printer.field.validation.click_to_test"  = "Click the icon to validate connectivity";
 "common.help.tooltip"                     = "More info";
 "common.help.learn_more"                  = "Learn more";
 "printer.help.url.body"                   = "Enter http://<ip> or http://<hostname> of your printer (for example http://192.168.1.42 or http://prusa-mk3.local). Open it in your web browser first to confirm PrusaLink loads.";

--- a/PrusaStatusBar/Resources/es.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/es.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "Ocultar clave API";
 "printer.field.display_name"              = "Nombre";
 "printer.url.test_help"                   = "Probar esta URL";
+"printer.field.validation.valid"          = "URL válida";
+"printer.field.validation.valid_host"     = "IP o nombre de host válido";
+"printer.field.validation.invalid_url"    = "URL no válida";
+"printer.field.validation.invalid_host"   = "Introduzca una IP o nombre de host válido";
+"printer.field.validation.click_to_test"  = "Haga clic en el icono para validar la conectividad";
 "common.help.tooltip"                     = "Más información";
 "common.help.learn_more"                  = "Más información";
 "printer.help.url.body"                   = "Introduce http://<ip> o http://<nombre_de_host> de tu impresora (por ejemplo http://192.168.1.42 o http://prusa-mk3.local). Ábrela primero en tu navegador para confirmar que PrusaLink se carga.";

--- a/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "Masquer la clé API";
 "printer.field.display_name"              = "Nom d'affichage";
 "printer.url.test_help"                   = "Tester cette URL";
+"printer.field.validation.valid"          = "URL valide";
+"printer.field.validation.valid_host"     = "IP ou nom d'hôte valide";
+"printer.field.validation.invalid_url"    = "URL invalide";
+"printer.field.validation.invalid_host"   = "Entrez une IP ou un nom d'hôte valide";
+"printer.field.validation.click_to_test"  = "Cliquez sur l'icône pour vérifier la connectivité";
 "common.help.tooltip"                     = "Plus d'infos";
 "common.help.learn_more"                  = "En savoir plus";
 "printer.help.url.body"                   = "Saisissez http://<ip> ou http://<nom_d_hote> de votre imprimante (par exemple http://192.168.1.42 ou http://prusa-mk3.local). Ouvrez l'adresse dans votre navigateur web pour vérifier que PrusaLink se charge.";

--- a/PrusaStatusBar/Resources/it.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/it.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "Nascondi chiave API";
 "printer.field.display_name"              = "Nome";
 "printer.url.test_help"                   = "Prova questo URL";
+"printer.field.validation.valid"          = "URL valido";
+"printer.field.validation.valid_host"     = "IP o hostname valido";
+"printer.field.validation.invalid_url"    = "URL non valido";
+"printer.field.validation.invalid_host"   = "Inserisci un IP o un hostname valido";
+"printer.field.validation.click_to_test"  = "Fai clic sull'icona per verificare la connettività";
 "common.help.tooltip"                     = "Maggiori info";
 "common.help.learn_more"                  = "Scopri di più";
 "printer.help.url.body"                   = "Inserisci http://<ip> o http://<hostname> della tua stampante (per esempio http://192.168.1.42 o http://prusa-mk3.local). Aprilo prima nel browser web per verificare che PrusaLink si carichi.";

--- a/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "APIキーを非表示";
 "printer.field.display_name"              = "表示名";
 "printer.url.test_help"                   = "このURLをテスト";
+"printer.field.validation.valid"          = "有効なURL";
+"printer.field.validation.valid_host"     = "有効なIPまたはホスト名";
+"printer.field.validation.invalid_url"    = "無効なURL";
+"printer.field.validation.invalid_host"   = "有効なIPまたはホスト名を入力してください";
+"printer.field.validation.click_to_test"  = "アイコンをクリックして接続を確認";
 "common.help.tooltip"                     = "詳細情報";
 "common.help.learn_more"                  = "詳しく見る";
 "printer.help.url.body"                   = "プリンターの http://<ip> または http://<hostname> を入力してください（例: http://192.168.1.42 または http://prusa-mk3.local）。先にブラウザでアドレスを開き、PrusaLink が表示されることを確認してください。";

--- a/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "Ukryj klucz API";
 "printer.field.display_name"              = "Nazwa";
 "printer.url.test_help"                   = "Przetestuj ten URL";
+"printer.field.validation.valid"          = "Prawidłowy URL";
+"printer.field.validation.valid_host"     = "Prawidłowy adres IP lub nazwa hosta";
+"printer.field.validation.invalid_url"    = "Nieprawidłowy URL";
+"printer.field.validation.invalid_host"   = "Wprowadź prawidłowy adres IP lub nazwę hosta";
+"printer.field.validation.click_to_test"  = "Kliknij ikonę, aby sprawdzić łączność";
 "common.help.tooltip"                     = "Więcej informacji";
 "common.help.learn_more"                  = "Dowiedz się więcej";
 "printer.help.url.body"                   = "Wprowadź http://<ip> lub http://<hostname> swojej drukarki (na przykład http://192.168.1.42 lub http://prusa-mk3.local). Najpierw otwórz adres w przeglądarce, aby potwierdzić, że PrusaLink się ładuje.";

--- a/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "Ocultar chave API";
 "printer.field.display_name"              = "Nome de exibição";
 "printer.url.test_help"                   = "Testar esta URL";
+"printer.field.validation.valid"          = "URL válida";
+"printer.field.validation.valid_host"     = "IP ou nome de host válido";
+"printer.field.validation.invalid_url"    = "URL inválida";
+"printer.field.validation.invalid_host"   = "Insira um IP ou nome de host válido";
+"printer.field.validation.click_to_test"  = "Clique no ícone para validar a conectividade";
 "common.help.tooltip"                     = "Mais informações";
 "common.help.learn_more"                  = "Saiba mais";
 "printer.help.url.body"                   = "Informe http://<ip> ou http://<hostname> da sua impressora (por exemplo http://192.168.1.42 ou http://prusa-mk3.local). Abra primeiro no navegador para confirmar que o PrusaLink carrega.";

--- a/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -163,6 +163,11 @@
 "printer.api_key.hide"                    = "隐藏 API 密钥";
 "printer.field.display_name"              = "显示名称";
 "printer.url.test_help"                   = "测试此 URL";
+"printer.field.validation.valid"          = "有效的网址";
+"printer.field.validation.valid_host"     = "有效的 IP 或主机名";
+"printer.field.validation.invalid_url"    = "无效的网址";
+"printer.field.validation.invalid_host"   = "请输入有效的 IP 或主机名";
+"printer.field.validation.click_to_test"  = "点击图标以验证连接";
 "common.help.tooltip"                     = "更多信息";
 "common.help.learn_more"                  = "了解更多";
 "printer.help.url.body"                   = "请输入打印机的 http://<ip> 或 http://<hostname>（例如 http://192.168.1.42 或 http://prusa-mk3.local）。先在浏览器中打开该地址，确认 PrusaLink 能够加载。";

--- a/PrusaStatusBar/Services/BuddyCameraHostDeriver.swift
+++ b/PrusaStatusBar/Services/BuddyCameraHostDeriver.swift
@@ -37,6 +37,9 @@ public enum BuddyCameraHostDeriver {
         guard let url = URL(string: "rtsp://\(trimmed):554/live/") else {
             return .failure(.containsSchemeOrPort)
         }
+        guard URLHostValidator.isValid(host: trimmed) else {
+            return .failure(.containsSchemeOrPort)
+        }
         return .success(url)
     }
 

--- a/PrusaStatusBar/Services/GenericCameraURLValidator.swift
+++ b/PrusaStatusBar/Services/GenericCameraURLValidator.swift
@@ -26,7 +26,8 @@ public enum GenericCameraURLValidator {
         }
         guard let url = URL(string: trimmed),
               let scheme = url.scheme?.lowercased(),
-              url.host?.isEmpty == false
+              let host = url.host,
+              !host.isEmpty
         else {
             return .invalid
         }
@@ -37,6 +38,9 @@ public enum GenericCameraURLValidator {
             ["http", "https"]
         }
         guard allowed.contains(scheme) else {
+            return .invalid
+        }
+        guard URLHostValidator.isValid(host: host) else {
             return .invalid
         }
         return .valid(url)

--- a/PrusaStatusBar/Services/PrinterBaseURLValidator.swift
+++ b/PrusaStatusBar/Services/PrinterBaseURLValidator.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Validates the PrusaLink primary and fallback URL fields on the Printer
+/// tab. Pure-syntactic check: trim whitespace, parse with `URL(string:)`,
+/// accept only `http` / `https`, and require a non-empty host. Matches the
+/// rules of `URLSessionPrusaLinkClient` so an input that passes here is
+/// always something the client could later try to connect to.
+public enum PrinterBaseURLValidator {
+    public enum Result: Equatable {
+        case empty
+        case valid(URL)
+        case invalid
+    }
+
+    public static func validate(_ raw: String) -> Result {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return .empty
+        }
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              let host = url.host,
+              !host.isEmpty
+        else {
+            return .invalid
+        }
+        guard scheme == "http" || scheme == "https" else {
+            return .invalid
+        }
+        guard URLHostValidator.isValid(host: host) else {
+            return .invalid
+        }
+        return .valid(url)
+    }
+}

--- a/PrusaStatusBar/Services/URLHostValidator.swift
+++ b/PrusaStatusBar/Services/URLHostValidator.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Network
+
+/// Shared syntactic check for the host component of any user-entered URL or
+/// host field on the Printer tab. `URL(string:)` accepts dotted-decimal
+/// strings like `192.168.94.1312` even though the last octet overflows, so
+/// every field that delegates to `URL(string:)` needs this extra guard.
+///
+/// Rules:
+/// - IPv4 literal (all digits + dots): must parse via `IPv4Address`.
+/// - IPv6 literal (contains `:`, with or without enclosing brackets): must
+///   parse via `IPv6Address`.
+/// - Anything else is treated as a DNS hostname and accepted; the caller is
+///   expected to have already verified non-emptiness via `URL.host`.
+public enum URLHostValidator {
+    public static func isValid(host: String) -> Bool {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let unbracketed: String = if trimmed.hasPrefix("["), trimmed.hasSuffix("]") {
+            String(trimmed.dropFirst().dropLast())
+        } else {
+            trimmed
+        }
+        if unbracketed.contains(":") {
+            return IPv6Address(unbracketed) != nil
+        }
+        let looksLikeIPv4 = unbracketed.allSatisfy { $0.isNumber || $0 == "." }
+        if looksLikeIPv4 {
+            return IPv4Address(unbracketed) != nil
+        }
+        return true
+    }
+}

--- a/PrusaStatusBar/UI/Components/BuddyCameraSection.swift
+++ b/PrusaStatusBar/UI/Components/BuddyCameraSection.swift
@@ -10,6 +10,7 @@ struct BuddyCameraSection: View {
     @Binding var enabled: Bool
     @Binding var cameraHost: String
     @Binding var cameraHostError: String?
+    let hostValidation: FieldValidationState
     let probe: RTSPProbing
     /// When false, the "Enable Buddy Camera" toggle is disabled and a tooltip
     /// explains why. The host row stays bound to the existing `enabled` flag,
@@ -53,7 +54,7 @@ struct BuddyCameraSection: View {
     }
 
     private var isTestDisabled: Bool {
-        trimmedHost.isEmpty || isTestingCamera
+        !hostValidation.isValid || isTestingCamera
     }
 
     private var enableToggleRow: some View {
@@ -75,7 +76,7 @@ struct BuddyCameraSection: View {
                 )
             } content: {
                 HStack(alignment: .center, spacing: Theme.Spacing.sml) {
-                    VStack(alignment: .trailing, spacing: 4) {
+                    VStack(alignment: .leading, spacing: 4) {
                         TextField(
                             "",
                             text: $cameraHost,
@@ -87,18 +88,18 @@ struct BuddyCameraSection: View {
                         .font(.prusaBody)
                         .lineLimit(1)
                         .frame(width: connectionFieldWidth)
-                        if let cameraHostError {
-                            Text(cameraHostError)
-                                .font(.prusaCaption)
-                                .foregroundStyle(Theme.Palette.stateRed)
-                        } else if !trimmedHost.isEmpty {
+                        if hostValidation.isValid, !derivedCaption.isEmpty {
                             Text(derivedCaption)
                                 .font(.prusaCaption)
                                 .foregroundStyle(Theme.Palette.textSecondary)
                                 .textSelection(.enabled)
                         }
+                        FieldValidationCaption(
+                            state: hostValidation,
+                            validLabel: L10n.t("printer.field.validation.valid_host")
+                        )
                     }
-                    .frame(maxWidth: .infinity)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
                     Button {
                         Task { await testCamera() }
                     } label: {

--- a/PrusaStatusBar/UI/Components/FieldValidationCaption.swift
+++ b/PrusaStatusBar/UI/Components/FieldValidationCaption.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Per-field syntactic validation state surfaced by `PrinterTab`. Drives
+/// the inline caption and gates each row's Test icon.
+enum FieldValidationState: Equatable {
+    case empty
+    case valid
+    case invalid(String)
+
+    var isValid: Bool {
+        if case .valid = self { return true }
+        return false
+    }
+}
+
+/// Single-line caption rendered under every Printer-tab text field that has
+/// an inline Test icon. Composes a colored validity prefix (green "Valid
+/// URL" / red reason) with the always-visible gray connectivity hint, joined
+/// by " - ". Empty field collapses to just the hint.
+struct FieldValidationCaption: View {
+    let state: FieldValidationState
+    let validLabel: String
+    let hint: String
+
+    init(
+        state: FieldValidationState,
+        validLabel: String = L10n.t("printer.field.validation.valid"),
+        hint: String = L10n.t("printer.field.validation.click_to_test")
+    ) {
+        self.state = state
+        self.validLabel = validLabel
+        self.hint = hint
+    }
+
+    var body: some View {
+        composedLine
+            .font(.prusaCaption)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var composedLine: Text {
+        let hintText = Text(hint).foregroundColor(Theme.Palette.textSecondary)
+        switch state {
+        case .empty:
+            return hintText
+        case .valid:
+            return Text(validLabel).foregroundColor(Theme.Palette.stateGreen)
+                + Text(" - ").foregroundColor(Theme.Palette.textSecondary)
+                + hintText
+        case let .invalid(message):
+            return Text(message).foregroundColor(Theme.Palette.stateRed)
+                + Text(" - ").foregroundColor(Theme.Palette.textSecondary)
+                + hintText
+        }
+    }
+}

--- a/PrusaStatusBar/UI/Components/GenericCameraCards.swift
+++ b/PrusaStatusBar/UI/Components/GenericCameraCards.swift
@@ -7,8 +7,8 @@ import SwiftUI
 struct GenericCameraSourcesCard: View {
     @Binding var streamURL: String
     @Binding var stillImageURL: String
-    let streamURLError: String?
-    let stillURLError: String?
+    let streamValidation: FieldValidationState
+    let stillValidation: FieldValidationState
     let isStreamTesting: Bool
     let isStillTesting: Bool
     let streamTestResult: PrinterTestResult?
@@ -23,9 +23,9 @@ struct GenericCameraSourcesCard: View {
                 systemImage: "antenna.radiowaves.left.and.right",
                 placeholder: "rtsp://192.168.1.50:554/stream1",
                 text: $streamURL,
-                error: streamURLError,
+                validation: streamValidation,
                 isTesting: isStreamTesting,
-                isTestDisabled: streamURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                isTestDisabled: !streamValidation.isValid,
                 testResult: streamTestResult,
                 onTest: onTestStream
             )
@@ -34,9 +34,9 @@ struct GenericCameraSourcesCard: View {
                 systemImage: "photo",
                 placeholder: "https://cam.local/snapshot.jpg",
                 text: $stillImageURL,
-                error: stillURLError,
+                validation: stillValidation,
                 isTesting: isStillTesting,
-                isTestDisabled: stillImageURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                isTestDisabled: !stillValidation.isValid,
                 testResult: stillTestResult,
                 onTest: onTestStill
             )
@@ -165,7 +165,7 @@ struct GenericCameraURLRow: View {
     let systemImage: String
     let placeholder: String
     @Binding var text: String
-    let error: String?
+    let validation: FieldValidationState
     let isTesting: Bool
     let isTestDisabled: Bool
     let testResult: PrinterTestResult?
@@ -201,11 +201,10 @@ struct GenericCameraURLRow: View {
                     .help(L10n.t("printer.url.test_help"))
                 }
             }
-            if let error {
-                Text(error)
-                    .font(.prusaCaption)
-                    .foregroundStyle(Theme.Palette.stateRed)
-                    .padding(.leading, connectionLabelWidth + Theme.Spacing.med)
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                FieldValidationCaption(state: validation)
+                    .frame(width: captionWidth, alignment: .leading)
             }
             if let testResult {
                 HStack(spacing: 0) {

--- a/PrusaStatusBar/UI/Components/GenericCameraSection.swift
+++ b/PrusaStatusBar/UI/Components/GenericCameraSection.swift
@@ -18,8 +18,8 @@ struct GenericCameraSection: View {
     @Binding var framerate: Int
     @Binding var verifySSL: Bool
     @Binding var contentType: String
-    @Binding var streamURLError: String?
-    @Binding var stillURLError: String?
+    let streamValidation: FieldValidationState
+    let stillValidation: FieldValidationState
     let probe: RTSPProbing
     let isPrinterURLSet: Bool
 
@@ -51,8 +51,8 @@ struct GenericCameraSection: View {
                 GenericCameraSourcesCard(
                     streamURL: $streamURL,
                     stillImageURL: $stillImageURL,
-                    streamURLError: streamURLError,
-                    stillURLError: stillURLError,
+                    streamValidation: streamValidation,
+                    stillValidation: stillValidation,
                     isStreamTesting: isStreamTesting,
                     isStillTesting: isStillTesting,
                     streamTestResult: streamTestResult,

--- a/PrusaStatusBar/UI/Components/PrinterTabSections.swift
+++ b/PrusaStatusBar/UI/Components/PrinterTabSections.swift
@@ -17,6 +17,10 @@ let connectionTestButtonReservedWidth: CGFloat = 28
 /// trailing alignment. Sized for the 520pt Preferences window.
 let connectionFieldWidth: CGFloat = 240
 
+/// Width of the inline validation caption row, sized to match the
+/// TextField + trailing Test button slot.
+let captionWidth: CGFloat = connectionFieldWidth + Theme.Spacing.sml + connectionTestButtonReservedWidth
+
 /// Body-key + external URL pair for the inline help popover shown in the
 /// label column of a Printer-tab row. Nil means no `?` button is rendered
 /// (e.g. the fallback URL row reuses the primary URL guidance).
@@ -93,6 +97,8 @@ struct PrinterURLRow: View {
     let isFallbackTestDisabled: Bool
     let primaryTestResult: PrinterTestResult?
     let fallbackTestResult: PrinterTestResult?
+    let urlValidation: FieldValidationState
+    let fallbackValidation: FieldValidationState
     let onTestPrimary: () -> Void
     let onTestFallback: () -> Void
 
@@ -106,6 +112,7 @@ struct PrinterURLRow: View {
                 isTesting: isPrimaryTesting,
                 isTestDisabled: isPrimaryTestDisabled,
                 result: primaryTestResult,
+                validation: urlValidation,
                 onTest: onTestPrimary,
                 helpInfo: PrinterHelpInfo(
                     bodyKey: "printer.help.url.body",
@@ -142,6 +149,7 @@ struct PrinterURLRow: View {
                         isTesting: isFallbackTesting,
                         isTestDisabled: isFallbackTestDisabled,
                         result: fallbackTestResult,
+                        validation: fallbackValidation,
                         onTest: onTestFallback,
                         helpInfo: nil
                     )
@@ -174,6 +182,7 @@ private struct URLTestableRow: View {
     let isTesting: Bool
     let isTestDisabled: Bool
     let result: PrinterTestResult?
+    let validation: FieldValidationState
     let onTest: () -> Void
     let helpInfo: PrinterHelpInfo?
 
@@ -206,6 +215,11 @@ private struct URLTestableRow: View {
                     .disabled(isTestDisabled || isTesting)
                     .help(L10n.t("printer.url.test_help"))
                 }
+            }
+            HStack(spacing: 0) {
+                Spacer(minLength: 0)
+                FieldValidationCaption(state: validation)
+                    .frame(width: captionWidth, alignment: .leading)
             }
             if let result {
                 HStack(spacing: 0) {

--- a/PrusaStatusBar/UI/PrinterTab.swift
+++ b/PrusaStatusBar/UI/PrinterTab.swift
@@ -20,8 +20,6 @@ struct PrinterTab: View {
     @State private var genericCameraFramerate: Int = UserPreferences.genericCameraFramerateDefault
     @State private var genericCameraVerifySSL: Bool = true
     @State private var genericCameraContentType: String = UserPreferences.genericCameraContentTypeDefault
-    @State private var genericCameraStreamURLError: String?
-    @State private var genericCameraStillURLError: String?
     @State var useKeychain: Bool = true
     /// Drives the keychain-toggle confirmation alert.
     @State var pendingKeychainToggle: Bool?
@@ -48,10 +46,12 @@ struct PrinterTab: View {
                     isFallbackExpanded: $isFallbackExpanded,
                     isPrimaryTesting: isPrimaryTesting,
                     isFallbackTesting: isFallbackTesting,
-                    isPrimaryTestDisabled: url.isEmpty || apiKey.isEmpty,
-                    isFallbackTestDisabled: fallbackURL.isEmpty || apiKey.isEmpty,
+                    isPrimaryTestDisabled: !urlValidation.isValid || apiKey.isEmpty,
+                    isFallbackTestDisabled: !fallbackURLValidation.isValid || apiKey.isEmpty,
                     primaryTestResult: primaryTestResult,
                     fallbackTestResult: fallbackTestResult,
+                    urlValidation: urlValidation,
+                    fallbackValidation: fallbackURLValidation,
                     onTestPrimary: { Task { await testPrimary() } },
                     onTestFallback: { Task { await testFallback() } }
                 )
@@ -71,6 +71,7 @@ struct PrinterTab: View {
                 enabled: $buddyCameraEnabled,
                 cameraHost: $cameraHost,
                 cameraHostError: $cameraHostError,
+                hostValidation: cameraHostValidation,
                 probe: services.rtspProbe,
                 isPrinterURLSet: isPrinterURLSet
             )
@@ -114,11 +115,58 @@ struct PrinterTab: View {
             framerate: $genericCameraFramerate,
             verifySSL: $genericCameraVerifySSL,
             contentType: $genericCameraContentType,
-            streamURLError: $genericCameraStreamURLError,
-            stillURLError: $genericCameraStillURLError,
+            streamValidation: genericCameraStreamValidation,
+            stillValidation: genericCameraStillValidation,
             probe: services.rtspProbe,
             isPrinterURLSet: isPrinterURLSet
         )
+    }
+
+    private var urlValidation: FieldValidationState {
+        Self.mapPrinterURL(PrinterBaseURLValidator.validate(url))
+    }
+
+    private var fallbackURLValidation: FieldValidationState {
+        Self.mapPrinterURL(PrinterBaseURLValidator.validate(fallbackURL))
+    }
+
+    private var cameraHostValidation: FieldValidationState {
+        let trimmed = cameraHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return .empty }
+        switch BuddyCameraHostDeriver.rtspURL(forHost: cameraHost) {
+        case .success: return .valid
+        case .failure(.empty): return .empty
+        case .failure(.containsSchemeOrPort):
+            return .invalid(L10n.t("printer.field.validation.invalid_host"))
+        }
+    }
+
+    private var genericCameraStreamValidation: FieldValidationState {
+        Self.mapGenericCameraURL(
+            GenericCameraURLValidator.validate(genericCameraStreamURL, field: .stream)
+        )
+    }
+
+    private var genericCameraStillValidation: FieldValidationState {
+        Self.mapGenericCameraURL(
+            GenericCameraURLValidator.validate(genericCameraStillURL, field: .still)
+        )
+    }
+
+    private static func mapPrinterURL(_ result: PrinterBaseURLValidator.Result) -> FieldValidationState {
+        switch result {
+        case .empty: .empty
+        case .valid: .valid
+        case .invalid: .invalid(L10n.t("printer.field.validation.invalid_url"))
+        }
+    }
+
+    private static func mapGenericCameraURL(_ result: GenericCameraURLValidator.Result) -> FieldValidationState {
+        switch result {
+        case .empty: .empty
+        case .valid: .valid
+        case .invalid: .invalid(L10n.t("printer.field.validation.invalid_url"))
+        }
     }
 
     /// Single equatable snapshot of every Generic Camera @State value.
@@ -218,8 +266,6 @@ private extension PrinterTab {
         genericCameraFramerate = services.settings.genericCameraFramerate
         genericCameraVerifySSL = services.settings.genericCameraVerifySSL
         genericCameraContentType = services.settings.genericCameraContentType
-        genericCameraStreamURLError = nil
-        genericCameraStillURLError = nil
         nameOverride = services.settings.printerNameOverride ?? ""
         cameraHostError = nil
     }
@@ -308,29 +354,17 @@ private extension PrinterTab {
 
     private func validateGenericStreamURL() -> String? {
         switch Self.validateGenericCameraURL(raw: genericCameraStreamURL, field: .stream) {
-        case .empty:
-            genericCameraStreamURLError = nil
-            return ""
-        case let .valid(value):
-            genericCameraStreamURLError = nil
-            return value
-        case .invalid:
-            genericCameraStreamURLError = L10n.t("printer.generic_camera.error.invalid_url")
-            return nil
+        case .empty: ""
+        case let .valid(value): value
+        case .invalid: nil
         }
     }
 
     private func validateGenericStillURL() -> String? {
         switch Self.validateGenericCameraURL(raw: genericCameraStillURL, field: .still) {
-        case .empty:
-            genericCameraStillURLError = nil
-            return ""
-        case let .valid(value):
-            genericCameraStillURLError = nil
-            return value
-        case .invalid:
-            genericCameraStillURLError = L10n.t("printer.generic_camera.error.invalid_url")
-            return nil
+        case .empty: ""
+        case let .valid(value): value
+        case .invalid: nil
         }
     }
 

--- a/PrusaStatusBarTests/PrinterBaseURLValidatorTests.swift
+++ b/PrusaStatusBarTests/PrinterBaseURLValidatorTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+@testable import PrusaStatusBar
+import Testing
+
+/// Spec coverage:
+/// - `menu-bar-ui` Requirement: Printer tab validates fields live as the user types
+///   (PrusaLink URL + fallback URL rules)
+struct PrinterBaseURLValidatorTests {
+    @Test
+    func emptyAndWhitespaceMapToEmpty() {
+        #expect(PrinterBaseURLValidator.validate("") == .empty)
+        #expect(PrinterBaseURLValidator.validate("   ") == .empty)
+        #expect(PrinterBaseURLValidator.validate("\t\n") == .empty)
+    }
+
+    @Test
+    func acceptsHttpAndHttps() {
+        guard case let .valid(httpURL) = PrinterBaseURLValidator.validate("http://printer.lan") else {
+            Issue.record("expected .valid for http")
+            return
+        }
+        #expect(httpURL.scheme == "http")
+        #expect(httpURL.host == "printer.lan")
+
+        guard case let .valid(httpsURL) = PrinterBaseURLValidator.validate("https://printer.lan") else {
+            Issue.record("expected .valid for https")
+            return
+        }
+        #expect(httpsURL.scheme == "https")
+    }
+
+    @Test
+    func acceptsUppercaseScheme() {
+        guard case .valid = PrinterBaseURLValidator.validate("HTTP://printer.lan") else {
+            Issue.record("expected .valid for uppercase scheme")
+            return
+        }
+    }
+
+    @Test
+    func acceptsPortAndPath() {
+        guard case let .valid(url) = PrinterBaseURLValidator.validate("http://printer.lan:8080/api") else {
+            Issue.record("expected .valid for url with port and path")
+            return
+        }
+        #expect(url.port == 8080)
+    }
+
+    @Test
+    func rejectsMissingScheme() {
+        #expect(PrinterBaseURLValidator.validate("printer.lan") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("printer.lan/api") == .invalid)
+    }
+
+    @Test
+    func rejectsDisallowedSchemes() {
+        #expect(PrinterBaseURLValidator.validate("ftp://printer.lan") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("file:///etc/hosts") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("javascript:alert(1)") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("rtsp://printer.lan/live") == .invalid)
+    }
+
+    @Test
+    func rejectsMissingHost() {
+        #expect(PrinterBaseURLValidator.validate("http://") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("http:///path") == .invalid)
+    }
+
+    @Test
+    func rejectsGarbage() {
+        #expect(PrinterBaseURLValidator.validate("not a url") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("http:// space") == .invalid)
+    }
+
+    @Test
+    func trimsWhitespaceBeforeValidating() {
+        guard case .valid = PrinterBaseURLValidator.validate("  http://printer.lan  ") else {
+            Issue.record("expected .valid after trim")
+            return
+        }
+    }
+
+    @Test
+    func acceptsValidIPv4Literal() {
+        guard case .valid = PrinterBaseURLValidator.validate("http://192.168.1.42") else {
+            Issue.record("expected .valid for 192.168.1.42")
+            return
+        }
+    }
+
+    @Test
+    func rejectsIPv4WithOctetOver255() {
+        #expect(PrinterBaseURLValidator.validate("http://192.168.94.1312") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("http://256.0.0.1") == .invalid)
+        #expect(PrinterBaseURLValidator.validate("http://1.2.3.999/path") == .invalid)
+    }
+
+    @Test
+    func acceptsValidIPv6Literal() {
+        guard case .valid = PrinterBaseURLValidator.validate("http://[::1]/api") else {
+            Issue.record("expected .valid for [::1]")
+            return
+        }
+        guard case .valid = PrinterBaseURLValidator.validate("http://[2001:db8::1]") else {
+            Issue.record("expected .valid for [2001:db8::1]")
+            return
+        }
+    }
+
+    @Test
+    func rejectsMalformedIPv6Literal() {
+        #expect(PrinterBaseURLValidator.validate("http://[::g]") == .invalid)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -132,6 +132,63 @@ Auth credentials are stored in the Keychain. Nothing leaves your network.
 - **Hardened Runtime** enabled for Release builds.
 - For vulnerabilities, see [SECURITY.md](SECURITY.md). Please do not file public issues.
 
+## Why not Prusa Connect?
+
+Prusa Connect is Prusa's cloud dashboard; PrusaLink is the local HTTP API that
+runs on the printer itself. Prusa StatusBar talks to PrusaLink, not Connect,
+because Connect has no public API for third-party desktop apps, and cannot be authenticated cleanly when you sign in to your Prusa account with Google or Facebook SSO. If you need to reach your printer from outside your home network, use the **Fallback URL** field in
+*Preferences > Printer* (a VPN, WireGuard, or Tailscale address works well).
+
+<details>
+<summary><strong>Technical details (for contributors)</strong></summary>
+
+The undocumented mobile API at
+`https://connect-mobile-api.prusa3d.com/api/docs` was probed end to end. The
+OpenAPI spec is tagged `version: 0.0.1-dev` (no stability contract).
+
+**Authentication blockers**
+
+- Auth scheme is OAuth2 Authorization Code + PKCE against
+  `https://account.prusa3d.com/o/authorize/`. The only client_id exposed is the
+  Connect web app's (`MRHTlZhZqkNrrQ6FUPtjyusAz8nc59ErHXP8XkS4`), and its
+  registered redirect URIs only accept `https://connect.prusa3d.com/*`.
+- Loopback redirect (`http://127.0.0.1:<port>/callback`, RFC 8252) and custom
+  URL schemes both fail with
+  `invalid_request: Mismatching redirect URI`.
+- Resource Owner Password grant (ROPC) is enabled server-side, but unusable for
+  the majority of users who sign in with Google or Facebook SSO (the IdP flow
+  cannot be proxied through a password grant).
+- Device Authorization Grant (RFC 8628) is disabled (`invalid_client`).
+- Embedded WKWebView interception is blocked by Google with
+  `disallowed_useragent` ("this browser may not be secure"), and Facebook
+  behaves the same way.
+- There is no public developer portal to register an app-specific client_id.
+
+**Telemetry gaps**
+
+The `Telemetry-with-telemetry` schema returned by `/api/v1/printers/{uuid}`
+only carries:
+
+```
+temperatureNozzleCurrent, temperatureNozzleTarget,
+temperatureHeatbedCurrent, temperatureHeatbedTarget,
+axisZ, speed, lastOnline
+```
+
+No chamber temperature (relevant for Core One and XL), no MMU status, no fan
+speeds, no nozzle diameter, no accurate `time_remaining` (only
+`estimatedPrintTime` plus `startAt`).
+
+**Conclusion**
+
+Even ignoring the Terms of Service grey area of reusing the web client_id,
+there is no clean auth path for SSO users and no feature parity with the
+local PrusaLink API. The app stays on PrusaLink. Chamber temperature, if
+needed, should be added by reading it from PrusaLink's `/api/v1/status` on
+firmware that exposes it (Core One, XL).
+
+</details>
+
 ## Contributing
 
 PRs are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) and


### PR DESCRIPTION
## Summary

Ensure IPs/hostname and URL information are valid.

## Checklist

- [X] Tests added or updated (Swift Testing).
- [X] `just check` passes locally.
- [X] `just test` passes locally.
- [X] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [X] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Add shared URL and host validation for printer and camera configuration fields and surface live validation feedback in the Printer preferences UI.

New Features:
- Introduce PrinterBaseURLValidator and URLHostValidator to validate printer URLs and IP/hostnames consistently across the app.
- Add FieldValidationState and FieldValidationCaption components to show inline validation status and testing hints under URL and host fields.

Enhancements:
- Wire printer, fallback, Buddy camera host, and generic camera URLs to the new validation layer to gate Test actions and replace ad-hoc error strings.
- Align GenericCameraURLValidator and BuddyCameraHostDeriver with the shared host validation rules for safer IP parsing.
- Tidy Printer tab layout with consistent caption width and alignment around validation and Test buttons.

Documentation:
- Document why the app targets local PrusaLink instead of Prusa Connect, including authentication and telemetry limitations, in the README.

Tests:
- Add unit tests for PrinterBaseURLValidator covering schemes, ports, paths, whitespace trimming, and IPv4/IPv6 edge cases.