### PR TITLE
feat: better support XL and INDX

### DIFF
--- a/PrusaStatusBar.xcodeproj/project.pbxproj
+++ b/PrusaStatusBar.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1126B362A751DFC125C8B18E /* GeneralTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D413B5006C1449975021ED6 /* GeneralTab.swift */; };
 		117D1A1B7F0C01A66ED42BF2 /* VLCMediaFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38CDDCD6AD8BD9A6D1D1865 /* VLCMediaFactory.swift */; };
 		121DB9311EA05DC2B4920D69 /* URLSessionPrusaLinkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DBFFE12DA3580F371C929B /* URLSessionPrusaLinkClient.swift */; };
+		14E8FFB0948F4F62EB59A0EF /* URLSessionPrusaLinkClient+Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916A827FB9BFAF37F8B7F9A7 /* URLSessionPrusaLinkClient+Diagnostics.swift */; };
 		15059BD04B8CCB1E45677093 /* PrinterTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147D8923B6615745AF78BBA5 /* PrinterTab.swift */; };
 		153F2B1E47E861CC1CB2C3A4 /* GenericCameraStillFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CC7AF58A303C88B79BC3CC /* GenericCameraStillFetcher.swift */; };
 		158AE8C4AD8B0F147EFE1929 /* PlainBorderedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D2FB535BF9AF2C0577C621 /* PlainBorderedTextField.swift */; };
@@ -69,6 +70,7 @@
 		51470AE91B3D2C4C49CB96A8 /* ApiKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D4980D62671D3948312CA9 /* ApiKeyStore.swift */; };
 		5221EABABF2C9919F32CA041 /* CardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11078DE113FB51EB6D59B41E /* CardStyle.swift */; };
 		561CE20656D508E55D068C53 /* SymbolPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7B9633A4068581A934EF18 /* SymbolPickerSheet.swift */; };
+		5873E89EDE32BE95CDD3082F /* PrinterDiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688BA83AEB806896DA58964E /* PrinterDiagnosticsTests.swift */; };
 		58E9D8B5BBBECAC10762AD8A /* CameraTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62E0CC8CC98F27EEEEF87FB /* CameraTile.swift */; };
 		59C94F8E1BF4DEB5F575CDCE /* UserPreferences+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7268D1B7D2597036B4B8629F /* UserPreferences+Appearance.swift */; };
 		5A2C9E4A14AC487E2FEF490B /* PrinterStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E178E275FBDA2FE99D38C46 /* PrinterStatus.swift */; };
@@ -180,6 +182,7 @@
 		E1BDB186EBC6D8E63E15205A /* MenuContentTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4D3BC5163899148D192BAB /* MenuContentTab.swift */; };
 		E422B15F61492BB8A890E2AC /* UserPreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC7322C3A0C4DDEF3A3DC473 /* UserPreferencesTests.swift */; };
 		E534F68B76F0FC7AF72C2F9C /* PrinterStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5587386878C425BB00FB8A88 /* PrinterStateTests.swift */; };
+		E57D8FD6A48425EDC00576F5 /* SupportDiagnosticsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE5C28E8502DB8A9C9D7AF6 /* SupportDiagnosticsSheet.swift */; };
 		E5F9C834C002FDA2B6356DBD /* PollingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6300AAF35702526B92279B /* PollingCoordinator.swift */; };
 		E8C7F44EE9D06F4B2B5BB89B /* JobCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC59D63576B844B108037F1 /* JobCard.swift */; };
 		E9279EFBCC8FA8185B76F545 /* StatusPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 690CE17E3BC554F68FCD1EC3 /* StatusPresenterTests.swift */; };
@@ -192,6 +195,7 @@
 		F98328131307EB566F6FE5EA /* PrinterTab+GenericCamera.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FBA2F2955E1A5636F65FFFB /* PrinterTab+GenericCamera.swift */; };
 		F9FA911924377FDA3CD9F45D /* BuddyCameraHostDeriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4464C09755EBFC0C6E8D4ACA /* BuddyCameraHostDeriver.swift */; };
 		FB44F2D39BC63F1C56EEAC62 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637394BBBC82C4CAAED977DF /* AppVersion.swift */; };
+		FDEECFFDBC9E066538812DD1 /* PrinterDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E88FCC611884B4A601367FFA /* PrinterDiagnostics.swift */; };
 		FF658FCFCB1BF7AA1E331B8D /* CameraQuickLookWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C4F1262C4A586437574B9D7 /* CameraQuickLookWindowController.swift */; };
 /* End PBXBuildFile section */
 
@@ -297,6 +301,7 @@
 		677AAEE9702751F9456E3BEC /* NotificationImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationImage.swift; sourceTree = "<group>"; };
 		679B3A8A09BE04C93111B7D2 /* GenericCameraConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericCameraConfigTests.swift; sourceTree = "<group>"; };
 		67AE0C8DA6D61794BD1ABEB5 /* CameraSnapshotServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraSnapshotServiceTests.swift; sourceTree = "<group>"; };
+		688BA83AEB806896DA58964E /* PrinterDiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterDiagnosticsTests.swift; sourceTree = "<group>"; };
 		68E0B6C0744DAA4A3D733E29 /* AboutTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTab.swift; sourceTree = "<group>"; };
 		690CE17E3BC554F68FCD1EC3 /* StatusPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPresenterTests.swift; sourceTree = "<group>"; };
 		6EBD690F68E4ED1C0EEE8583 /* CustomActionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionsSection.swift; sourceTree = "<group>"; };
@@ -330,6 +335,7 @@
 		8B49C6B2A4F9978C06F5CAF4 /* BuddyCameraToggleGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddyCameraToggleGateTests.swift; sourceTree = "<group>"; };
 		8E0AC5858D7126443E050D4E /* ActionsSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionsSectionTests.swift; sourceTree = "<group>"; };
 		8EB26612ACE4C9B1A50BA980 /* PrusaLinkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrusaLinkError.swift; sourceTree = "<group>"; };
+		916A827FB9BFAF37F8B7F9A7 /* URLSessionPrusaLinkClient+Diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionPrusaLinkClient+Diagnostics.swift"; sourceTree = "<group>"; };
 		917FAD85518D848DBF7AF41F /* PrusaLinkErrorMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrusaLinkErrorMappingTests.swift; sourceTree = "<group>"; };
 		961D751A823A11F8AA0A0ED9 /* GitHubReleaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubReleaseClient.swift; sourceTree = "<group>"; };
 		96AB4CBC6D9EE513C065C9D6 /* StillImagePollerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StillImagePollerView.swift; sourceTree = "<group>"; };
@@ -374,6 +380,7 @@
 		C30D7B0247E18C91AEFE4A25 /* AppServicesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppServicesTests.swift; sourceTree = "<group>"; };
 		C8B62CEA9034D1A5AAF8624E /* RTSPProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RTSPProbeTests.swift; sourceTree = "<group>"; };
 		CB72F57A1677554A863F510D /* LiveMetricsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMetricsCard.swift; sourceTree = "<group>"; };
+		CCE5C28E8502DB8A9C9D7AF6 /* SupportDiagnosticsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportDiagnosticsSheet.swift; sourceTree = "<group>"; };
 		CDBC80AD46C08C88F1B440AD /* PrinterTabSections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterTabSections.swift; sourceTree = "<group>"; };
 		CE586F52EE91EB854CC28633 /* PrusaLinkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrusaLinkClient.swift; sourceTree = "<group>"; };
 		CED036D96CCA8731010B0E08 /* KeychainToggleConfirmationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainToggleConfirmationTests.swift; sourceTree = "<group>"; };
@@ -398,6 +405,7 @@
 		E55BAC4904D12A9C4A979CE5 /* CameraStreamKeepaliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraStreamKeepaliveTests.swift; sourceTree = "<group>"; };
 		E62E0CC8CC98F27EEEEF87FB /* CameraTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraTile.swift; sourceTree = "<group>"; };
 		E6C69573362E773CF8621112 /* GenericCameraSection+Test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GenericCameraSection+Test.swift"; sourceTree = "<group>"; };
+		E88FCC611884B4A601367FFA /* PrinterDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrinterDiagnostics.swift; sourceTree = "<group>"; };
 		E9837A8DDC769BBEC409ECB0 /* GenericCameraURLValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericCameraURLValidatorTests.swift; sourceTree = "<group>"; };
 		E98BC8C8787FF5C5A879E043 /* FieldValidationCaption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldValidationCaption.swift; sourceTree = "<group>"; };
 		EA270CAFE1C767224C955D2B /* PrusaLinkResponseDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrusaLinkResponseDecoding.swift; sourceTree = "<group>"; };
@@ -511,6 +519,7 @@
 				D1CEA6F5D7BD2C8B5C2659B4 /* PollingCoordinator+Notifications.swift */,
 				0561CD4C3F3F048B786A8D6B /* PollingCoordinator+Started.swift */,
 				2BB03CDE6299245F9832F91C /* PrinterBaseURLValidator.swift */,
+				E88FCC611884B4A601367FFA /* PrinterDiagnostics.swift */,
 				CE586F52EE91EB854CC28633 /* PrusaLinkClient.swift */,
 				EA270CAFE1C767224C955D2B /* PrusaLinkResponseDecoding.swift */,
 				650D002FB5F5CCB2FE73F06A /* RTSPProbe.swift */,
@@ -525,6 +534,7 @@
 				3A047474263C8051324C2145 /* URLHostValidator.swift */,
 				76A28666046C15B3988ED729 /* URLSessionGitHubReleaseClient.swift */,
 				29DBFFE12DA3580F371C929B /* URLSessionPrusaLinkClient.swift */,
+				916A827FB9BFAF37F8B7F9A7 /* URLSessionPrusaLinkClient+Diagnostics.swift */,
 				4526FE5ADC7EA3CB56022219 /* UserPreferences.swift */,
 				7268D1B7D2597036B4B8629F /* UserPreferences+Appearance.swift */,
 				E1DAA7E6CB94AE41C7F7F1F4 /* UserPreferences+CustomActions.swift */,
@@ -580,6 +590,7 @@
 				9FBA2F2955E1A5636F65FFFB /* PrinterTab+GenericCamera.swift */,
 				D56E480080DDB6D31572A308 /* PrinterTab+Keychain.swift */,
 				B6AF9F26343DEAA49A3576A7 /* PrintingIconAnimator.swift */,
+				CCE5C28E8502DB8A9C9D7AF6 /* SupportDiagnosticsSheet.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -655,6 +666,7 @@
 				01E6CDDD0D76BB029B8825B7 /* PollingCoordinatorIntervalTests.swift */,
 				40820872A7703EB26D27F4E6 /* PopoverLifecycleTests.swift */,
 				D192C2F790D169C82B974C4B /* PrinterBaseURLValidatorTests.swift */,
+				688BA83AEB806896DA58964E /* PrinterDiagnosticsTests.swift */,
 				5587386878C425BB00FB8A88 /* PrinterStateTests.swift */,
 				8892FCD27EA15ADC1D87DD6B /* PrintingIconAnimatorTests.swift */,
 				917FAD85518D848DBF7AF41F /* PrusaLinkErrorMappingTests.swift */,
@@ -882,6 +894,7 @@
 				8BD0D270D5E8F2A37C5C3C08 /* PollingCoordinatorIntervalTests.swift in Sources */,
 				34D25079A797278C3DFD579A /* PopoverLifecycleTests.swift in Sources */,
 				D1A1E47B0D8ADA00CD560AFC /* PrinterBaseURLValidatorTests.swift in Sources */,
+				5873E89EDE32BE95CDD3082F /* PrinterDiagnosticsTests.swift in Sources */,
 				E534F68B76F0FC7AF72C2F9C /* PrinterStateTests.swift in Sources */,
 				7844465B9AFE738EF4B0306D /* PrintingIconAnimatorTests.swift in Sources */,
 				69DB2C0ED8197DCF219CE716 /* PrusaLinkErrorMappingTests.swift in Sources */,
@@ -993,6 +1006,7 @@
 				E5F9C834C002FDA2B6356DBD /* PollingCoordinator.swift in Sources */,
 				9892F61C7B50D5C7750441C4 /* PreferencesWindow.swift in Sources */,
 				B02A47E4C2A239E6B714B088 /* PrinterBaseURLValidator.swift in Sources */,
+				FDEECFFDBC9E066538812DD1 /* PrinterDiagnostics.swift in Sources */,
 				A830BC1C0BBF81CCFA125484 /* PrinterKeychainConfirmation.swift in Sources */,
 				B6DC0419AD06204E8E265296 /* PrinterNotificationHintSection.swift in Sources */,
 				5CE3B29D074AE5B898FE1E73 /* PrinterState.swift in Sources */,
@@ -1023,12 +1037,14 @@
 				2C807A2B4C6C1E2BF6801916 /* StreamRetryPolicy.swift in Sources */,
 				21F2497A38F1B8FE8EC6BD87 /* StubGitHubReleaseClient.swift in Sources */,
 				4596E98ACDBC6D961F6C47FA /* StubPrusaLinkClient.swift in Sources */,
+				E57D8FD6A48425EDC00576F5 /* SupportDiagnosticsSheet.swift in Sources */,
 				675C19DDCD9C80DA9E2C645F /* SymbolCatalog.swift in Sources */,
 				561CE20656D508E55D068C53 /* SymbolPickerSheet.swift in Sources */,
 				BF4529BD4AAC0D9124205D56 /* TempCard.swift in Sources */,
 				BAFFA0C477089A0535556F0C /* Theme.swift in Sources */,
 				406805AAB4ED041E734E37B3 /* URLHostValidator.swift in Sources */,
 				610A9FB1B5749026AD783535 /* URLSessionGitHubReleaseClient.swift in Sources */,
+				14E8FFB0948F4F62EB59A0EF /* URLSessionPrusaLinkClient+Diagnostics.swift in Sources */,
 				121DB9311EA05DC2B4920D69 /* URLSessionPrusaLinkClient.swift in Sources */,
 				1DAD26FD77459279800E2B94 /* UnconfiguredCard.swift in Sources */,
 				BADF66BA72FB74221270BD03 /* UpdateChecker.swift in Sources */,

--- a/PrusaStatusBar.xcodeproj/project.pbxproj
+++ b/PrusaStatusBar.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		1126B362A751DFC125C8B18E /* GeneralTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D413B5006C1449975021ED6 /* GeneralTab.swift */; };
 		117D1A1B7F0C01A66ED42BF2 /* VLCMediaFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38CDDCD6AD8BD9A6D1D1865 /* VLCMediaFactory.swift */; };
 		121DB9311EA05DC2B4920D69 /* URLSessionPrusaLinkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DBFFE12DA3580F371C929B /* URLSessionPrusaLinkClient.swift */; };
+		13223287FA587A2B76862F7B /* MenuContentTab+Nozzles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8135BA7D019988B31AEE6354 /* MenuContentTab+Nozzles.swift */; };
 		14E8FFB0948F4F62EB59A0EF /* URLSessionPrusaLinkClient+Diagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 916A827FB9BFAF37F8B7F9A7 /* URLSessionPrusaLinkClient+Diagnostics.swift */; };
 		15059BD04B8CCB1E45677093 /* PrinterTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147D8923B6615745AF78BBA5 /* PrinterTab.swift */; };
 		153F2B1E47E861CC1CB2C3A4 /* GenericCameraStillFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62CC7AF58A303C88B79BC3CC /* GenericCameraStillFetcher.swift */; };
@@ -161,6 +162,7 @@
 		BCDF2FCF8554104242D4BF32 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EB20800998290BD35E5563 /* Log.swift */; };
 		BD7BEA1F1D8A237A0C9EB35C /* BuddyCameraHostDeriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC508959AAD00D6DB613034E /* BuddyCameraHostDeriverTests.swift */; };
 		BF4529BD4AAC0D9124205D56 /* TempCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B02F4751AAAF8DC15616DD /* TempCard.swift */; };
+		C10B76EC0B8595EAB79B93D6 /* UserPreferences+Nozzles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E179C0EB12A316EE2A092C48 /* UserPreferences+Nozzles.swift */; };
 		C16232FC2D59A5C38CE12A1D /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16026281D1D3478F07405152 /* L10n.swift */; };
 		C335F30B69848D54D99B2D26 /* ProgressBarPremium.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDF6247719EB661D35E2F75 /* ProgressBarPremium.swift */; };
 		C5984F3355F846704B772032 /* MJPEGFrameGrabber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035D1BED27D7FD86EA045139 /* MJPEGFrameGrabber.swift */; };
@@ -325,6 +327,7 @@
 		7D413B5006C1449975021ED6 /* GeneralTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralTab.swift; sourceTree = "<group>"; };
 		7F6F8110A622470926C247DE /* TempCardArrowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempCardArrowStateTests.swift; sourceTree = "<group>"; };
 		80E437CA0200D1D803623DD6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8135BA7D019988B31AEE6354 /* MenuContentTab+Nozzles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MenuContentTab+Nozzles.swift"; sourceTree = "<group>"; };
 		816C9EDB1DDC6DCFD7C7E377 /* Fonts */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Fonts; path = PrusaStatusBar/Resources/Fonts; sourceTree = SOURCE_ROOT; };
 		83451F1C94F8CD12C7449A73 /* CustomActionSlotBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionSlotBody.swift; sourceTree = "<group>"; };
 		84D8B0B7A174DDABDDF05031 /* VLCSnapshotGrabber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCSnapshotGrabber.swift; sourceTree = "<group>"; };
@@ -398,6 +401,7 @@
 		DF1CD8B1C2B5DE32CBB38E94 /* CameraQuickLookCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraQuickLookCoordinator.swift; sourceTree = "<group>"; };
 		DFE76CF22C0FD564C030BFF6 /* FooterBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FooterBar.swift; sourceTree = "<group>"; };
 		E012958219D387974AE1ED2E /* StubLoginItemServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubLoginItemServiceTests.swift; sourceTree = "<group>"; };
+		E179C0EB12A316EE2A092C48 /* UserPreferences+Nozzles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserPreferences+Nozzles.swift"; sourceTree = "<group>"; };
 		E1DAA7E6CB94AE41C7F7F1F4 /* UserPreferences+CustomActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserPreferences+CustomActions.swift"; sourceTree = "<group>"; };
 		E38CDDCD6AD8BD9A6D1D1865 /* VLCMediaFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VLCMediaFactory.swift; sourceTree = "<group>"; };
 		E47401C33A9E6885BFF765E0 /* CustomActionSlotCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomActionSlotCard.swift; sourceTree = "<group>"; };
@@ -539,6 +543,7 @@
 				7268D1B7D2597036B4B8629F /* UserPreferences+Appearance.swift */,
 				E1DAA7E6CB94AE41C7F7F1F4 /* UserPreferences+CustomActions.swift */,
 				7BE88BE985A1446B62541F26 /* UserPreferences+GenericCamera.swift */,
+				E179C0EB12A316EE2A092C48 /* UserPreferences+Nozzles.swift */,
 				A13ED48F8B7892A0CF720795 /* UserPreferences+StartedNotification.swift */,
 				6FC002ACD12B11348739B8C9 /* UserPreferences+UpdateCheck.swift */,
 				E38CDDCD6AD8BD9A6D1D1865 /* VLCMediaFactory.swift */,
@@ -585,6 +590,7 @@
 				EF197CE19922CEA59FDA6051 /* MenuBarController+PrintingIcon.swift */,
 				4749B3AFCE39425667A3FBC2 /* MenuBarTab.swift */,
 				5E4D3BC5163899148D192BAB /* MenuContentTab.swift */,
+				8135BA7D019988B31AEE6354 /* MenuContentTab+Nozzles.swift */,
 				796B7A9C12A1BD276619A187 /* PreferencesWindow.swift */,
 				147D8923B6615745AF78BBA5 /* PrinterTab.swift */,
 				9FBA2F2955E1A5636F65FFFB /* PrinterTab+GenericCamera.swift */,
@@ -996,6 +1002,7 @@
 				A9CFEC1E0D44281FECFE40A7 /* MenuBarController+PrintingIcon.swift in Sources */,
 				42AAA9655AAFBD70431775E3 /* MenuBarController.swift in Sources */,
 				F1C017114FCD9FD9BB1BD504 /* MenuBarTab.swift in Sources */,
+				13223287FA587A2B76862F7B /* MenuContentTab+Nozzles.swift in Sources */,
 				E1BDB186EBC6D8E63E15205A /* MenuContentTab.swift in Sources */,
 				9E01EB023DBAC132FB582F76 /* NotificationImage.swift in Sources */,
 				B5C1FFE030E3C8981CC923A2 /* NotificationService.swift in Sources */,
@@ -1051,6 +1058,7 @@
 				59C94F8E1BF4DEB5F575CDCE /* UserPreferences+Appearance.swift in Sources */,
 				99B85BE321C085470AAA8E3A /* UserPreferences+CustomActions.swift in Sources */,
 				5D7FE52CE2FE1B5FB31B332A /* UserPreferences+GenericCamera.swift in Sources */,
+				C10B76EC0B8595EAB79B93D6 /* UserPreferences+Nozzles.swift in Sources */,
 				D4C34F96438E472C7D50BAFA /* UserPreferences+StartedNotification.swift in Sources */,
 				72F00E8D93982E7D64DF7B02 /* UserPreferences+UpdateCheck.swift in Sources */,
 				94BC313C832769CE6B61BC6A /* UserPreferences.swift in Sources */,
@@ -1187,7 +1195,7 @@
 					"zh-Hans",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1317,7 +1325,7 @@
 					"zh-Hans",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1417,7 +1425,7 @@
 					"zh-Hans",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.3.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;

--- a/PrusaStatusBar/Model/AppModel.swift
+++ b/PrusaStatusBar/Model/AppModel.swift
@@ -56,6 +56,7 @@ public final class AppModel {
     public var showSpeed: Bool = false
     public var showZHeight: Bool = false
     public var showNozzleDiameter: Bool = false
+    public var configuredNozzleDiameters: [Double] = []
     public var showFilamentType: Bool = true
     public var showMMU: Bool = false
     public var showTemperatures: Bool = true
@@ -157,6 +158,18 @@ public final class AppModel {
         !printerBaseURL.isEmpty && apiKeyConfigured
     }
 
+    /// Manual multi-tool diameters take precedence. With no manual setup the
+    /// single value reported by PrusaLink keeps the existing behavior.
+    public var effectiveNozzleDiameters: [Double] {
+        if configuredNozzleDiameters.count >= 2 {
+            return configuredNozzleDiameters
+        }
+        guard let diameter = printerInfo?.nozzleDiameter, diameter.isFinite, diameter > 0 else {
+            return []
+        }
+        return [diameter]
+    }
+
     /// Refreshes every setting mirror from the injected services so views
     /// observing the model see the same values as on-disk preferences. The
     /// prototype-mode override that fakes "configured" stays in `AppDelegate`
@@ -178,6 +191,7 @@ public final class AppModel {
         showSpeed = services.settings.showSpeed
         showZHeight = services.settings.showZHeight
         showNozzleDiameter = services.settings.showNozzleDiameter
+        configuredNozzleDiameters = services.settings.configuredNozzleDiameters
         showFilamentType = services.settings.showFilamentType
         showMMU = services.settings.showMMU
         showTemperatures = services.settings.showTemperatures

--- a/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "Zobrazit rychlost tisku";
 "content.metrics.z_height.label"          = "Zobrazit výšku Z";
 "content.metrics.nozzle_diameter.label"   = "Zobrazit průměr trysky";
+"content.metrics.nozzle_setup.label"      = "Nastavení trysek";
+"content.metrics.nozzle_setup.automatic"  = "Automaticky (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld nástrojů";
+"content.metrics.nozzle_tool.label"       = "Nástroj %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink u vícenástrojových tiskáren hlásí pouze nástroj 1. Zadejte průměr trysky každého nástroje, aby se zobrazovaly samostatně.";
 "content.metrics.filament_type.label"     = "Zobrazit typ filamentu";
 "content.metrics.mmu.label"               = "Zobrazit MMU";
 "content.job_control.header"              = "Ovládání tisku";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "Rychlost";
 "dropdown.metrics.z_height"               = "Výška Z";
 "dropdown.metrics.nozzle_diameter"        = "Průměr trysky";
+"dropdown.metrics.nozzle_diameter.tool"   = "Tryska nástroje %lld";
 "dropdown.metrics.filament_type"          = "Filament";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Povoleno";

--- a/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/cs.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "Podpoř vývojáře";
 "about.version"                           = "Verze %@ (%@)";
+"about.diagnostics.title"                 = "Diagnostika podpory";
+"about.diagnostics.description"           = "Tiskárna musí být zapnutá a dostupná. Před vytvořením reportu se ověří přístup k API.";
+"about.diagnostics.copy"                  = "Kopírovat diagnostický report";
+"about.diagnostics.checking"              = "Kontrola tiskárny…";
+"about.diagnostics.copied"                = "Report zkopírován. Vložte ho do issue na GitHubu.";
+"about.diagnostics.privacy"               = "Report nikdy neobsahuje API klíč, adresu ani osobní identifikátory.";
+"about.diagnostics.close"                 = "Hotovo";
+"about.diagnostics.invalid_response"      = "Tiskárna vrátila neplatnou diagnostickou odpověď.";
 
 // Footer
 "footer.preferences"                      = "Nastavení";

--- a/PrusaStatusBar/Resources/de.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/de.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "Den Entwickler unterstützen";
 "about.version"                           = "Version %@ (%@)";
+"about.diagnostics.title"                 = "Supportdiagnose";
+"about.diagnostics.description"           = "Der Drucker muss eingeschaltet und erreichbar sein. Der API-Zugriff wird vor der Berichterstellung geprüft.";
+"about.diagnostics.copy"                  = "Diagnosebericht kopieren";
+"about.diagnostics.checking"              = "Drucker wird geprüft…";
+"about.diagnostics.copied"                = "Bericht kopiert. Fügen Sie ihn in ein GitHub-Issue ein.";
+"about.diagnostics.privacy"               = "Der Bericht enthält niemals Ihren API-Schlüssel, Ihre Adresse oder persönliche Kennungen.";
+"about.diagnostics.close"                 = "Fertig";
+"about.diagnostics.invalid_response"      = "Der Drucker hat eine ungültige Diagnoseantwort zurückgegeben.";
 
 // Footer
 "footer.preferences"                      = "Einstellungen";

--- a/PrusaStatusBar/Resources/de.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/de.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "Druckgeschwindigkeit anzeigen";
 "content.metrics.z_height.label"          = "Z-Höhe anzeigen";
 "content.metrics.nozzle_diameter.label"   = "Düsendurchmesser anzeigen";
+"content.metrics.nozzle_setup.label"      = "Düsenkonfiguration";
+"content.metrics.nozzle_setup.automatic"  = "Automatisch (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld Werkzeuge";
+"content.metrics.nozzle_tool.label"       = "Werkzeug %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink meldet bei Multi-Tool-Druckern nur Werkzeug 1. Gib den Düsendurchmesser für jedes Werkzeug ein, um sie einzeln anzuzeigen.";
 "content.metrics.filament_type.label"     = "Filamenttyp anzeigen";
 "content.metrics.mmu.label"               = "MMU anzeigen";
 "content.job_control.header"              = "Auftragssteuerung";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "Geschwindigkeit";
 "dropdown.metrics.z_height"               = "Z-Höhe";
 "dropdown.metrics.nozzle_diameter"        = "Düsendurchmesser";
+"dropdown.metrics.nozzle_diameter.tool"   = "Düse Werkzeug %lld";
 "dropdown.metrics.filament_type"          = "Filament";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Aktiviert";

--- a/PrusaStatusBar/Resources/en.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/en.lproj/Localizable.strings
@@ -55,6 +55,11 @@
 "content.metrics.speed.label"             = "Show printing speed";
 "content.metrics.z_height.label"          = "Show Z-height";
 "content.metrics.nozzle_diameter.label"   = "Show nozzle diameter";
+"content.metrics.nozzle_setup.label"      = "Nozzle setup";
+"content.metrics.nozzle_setup.automatic"  = "Automatic (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld tools";
+"content.metrics.nozzle_tool.label"       = "Tool %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink reports only Tool 1 on multi-tool printers. Enter each tool's nozzle diameter to show them separately.";
 "content.metrics.filament_type.label"     = "Show filament type";
 "content.metrics.mmu.label"               = "Show MMU";
 "content.job_control.header"              = "Job control";
@@ -185,6 +190,7 @@
 "dropdown.metrics.speed"                  = "Speed";
 "dropdown.metrics.z_height"               = "Z-height";
 "dropdown.metrics.nozzle_diameter"        = "Nozzle diameter";
+"dropdown.metrics.nozzle_diameter.tool"   = "Tool %lld nozzle";
 "dropdown.metrics.filament_type"          = "Filament";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Enabled";

--- a/PrusaStatusBar/Resources/en.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/en.lproj/Localizable.strings
@@ -221,6 +221,14 @@
 "about.go2rtc_credit"                     = "Live video powered by VLCKit (LGPL)";
 "about.community_notice"                  = "Community application, Non Prusa Official";
 "about.version"                           = "Version %@ (%@)";
+"about.diagnostics.title"                 = "Support diagnostics";
+"about.diagnostics.description"           = "The printer must be on and reachable. API access is verified before the report is created.";
+"about.diagnostics.copy"                  = "Copy diagnostic report";
+"about.diagnostics.checking"              = "Checking printer…";
+"about.diagnostics.copied"                = "Report copied. Paste it into a GitHub issue.";
+"about.diagnostics.privacy"               = "The report never includes your API key, address, or personal identifiers.";
+"about.diagnostics.close"                 = "Done";
+"about.diagnostics.invalid_response"      = "The printer returned an invalid diagnostic response.";
 
 // Misc
 "misc.refresh_interval.custom"            = "Custom";

--- a/PrusaStatusBar/Resources/es.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/es.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "Mostrar velocidad de impresión";
 "content.metrics.z_height.label"          = "Mostrar altura Z";
 "content.metrics.nozzle_diameter.label"   = "Mostrar diámetro de boquilla";
+"content.metrics.nozzle_setup.label"      = "Configuración de boquillas";
+"content.metrics.nozzle_setup.automatic"  = "Automático (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld herramientas";
+"content.metrics.nozzle_tool.label"       = "Herramienta %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink solo informa de la herramienta 1 en impresoras multiherramienta. Introduce el diámetro de la boquilla de cada herramienta para mostrarlos por separado.";
 "content.metrics.filament_type.label"     = "Mostrar tipo de filamento";
 "content.metrics.mmu.label"               = "Mostrar MMU";
 "content.job_control.header"              = "Control de impresión";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "Velocidad";
 "dropdown.metrics.z_height"               = "Altura Z";
 "dropdown.metrics.nozzle_diameter"        = "Diámetro de boquilla";
+"dropdown.metrics.nozzle_diameter.tool"   = "Boquilla herramienta %lld";
 "dropdown.metrics.filament_type"          = "Filamento";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Activado";

--- a/PrusaStatusBar/Resources/es.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/es.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "Apoyar al desarrollador";
 "about.version"                           = "Versión %@ (%@)";
+"about.diagnostics.title"                 = "Diagnóstico de asistencia";
+"about.diagnostics.description"           = "La impresora debe estar encendida y accesible. El acceso a la API se verifica antes de crear el informe.";
+"about.diagnostics.copy"                  = "Copiar informe de diagnóstico";
+"about.diagnostics.checking"              = "Comprobando impresora…";
+"about.diagnostics.copied"                = "Informe copiado. Péguelo en una incidencia de GitHub.";
+"about.diagnostics.privacy"               = "El informe nunca incluye su clave API, dirección ni identificadores personales.";
+"about.diagnostics.close"                 = "Listo";
+"about.diagnostics.invalid_response"      = "La impresora devolvió una respuesta de diagnóstico no válida.";
 
 // Footer
 "footer.preferences"                      = "Ajustes";

--- a/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "Soutenir le développeur";
 "about.version"                           = "Version %@ (%@)";
+"about.diagnostics.title"                 = "Diagnostic d’assistance";
+"about.diagnostics.description"           = "L’imprimante doit être allumée et accessible. L’accès à l’API est vérifié avant de créer le rapport.";
+"about.diagnostics.copy"                  = "Copier le rapport de diagnostic";
+"about.diagnostics.checking"              = "Vérification de l’imprimante…";
+"about.diagnostics.copied"                = "Rapport copié. Collez-le dans une issue GitHub.";
+"about.diagnostics.privacy"               = "Le rapport ne contient ni clé API, ni adresse, ni identifiant personnel.";
+"about.diagnostics.close"                 = "Terminé";
+"about.diagnostics.invalid_response"      = "L’imprimante a renvoyé une réponse de diagnostic invalide.";
 
 // Footer
 "footer.preferences"                      = "Préférences";

--- a/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/fr.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "Afficher vitesse d'impression";
 "content.metrics.z_height.label"          = "Afficher hauteur Z";
 "content.metrics.nozzle_diameter.label"   = "Afficher diamètre de buse";
+"content.metrics.nozzle_setup.label"      = "Configuration des buses";
+"content.metrics.nozzle_setup.automatic"  = "Automatique (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld outils";
+"content.metrics.nozzle_tool.label"       = "Outil %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink ne remonte que l’outil 1 sur les imprimantes multi-outils. Renseignez le diamètre de chaque buse pour les afficher séparément.";
 "content.metrics.filament_type.label"     = "Afficher type de filament";
 "content.metrics.mmu.label"               = "Afficher MMU";
 "content.job_control.header"              = "Contrôle d'impression";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "Vitesse";
 "dropdown.metrics.z_height"               = "Hauteur Z";
 "dropdown.metrics.nozzle_diameter"        = "Diamètre buse";
+"dropdown.metrics.nozzle_diameter.tool"   = "Buse outil %lld";
 "dropdown.metrics.filament_type"          = "Filament";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Activé";

--- a/PrusaStatusBar/Resources/it.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/it.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "Sostieni lo sviluppatore";
 "about.version"                           = "Versione %@ (%@)";
+"about.diagnostics.title"                 = "Diagnostica assistenza";
+"about.diagnostics.description"           = "La stampante deve essere accesa e raggiungibile. L’accesso API viene verificato prima di creare il rapporto.";
+"about.diagnostics.copy"                  = "Copia rapporto diagnostico";
+"about.diagnostics.checking"              = "Verifica della stampante…";
+"about.diagnostics.copied"                = "Rapporto copiato. Incollalo in una segnalazione GitHub.";
+"about.diagnostics.privacy"               = "Il rapporto non include mai chiave API, indirizzo o identificativi personali.";
+"about.diagnostics.close"                 = "Fine";
+"about.diagnostics.invalid_response"      = "La stampante ha restituito una risposta diagnostica non valida.";
 
 // Footer
 "footer.preferences"                      = "Impostazioni";

--- a/PrusaStatusBar/Resources/it.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/it.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "Mostra velocità di stampa";
 "content.metrics.z_height.label"          = "Mostra altezza Z";
 "content.metrics.nozzle_diameter.label"   = "Mostra diametro ugello";
+"content.metrics.nozzle_setup.label"      = "Configurazione ugelli";
+"content.metrics.nozzle_setup.automatic"  = "Automatico (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld strumenti";
+"content.metrics.nozzle_tool.label"       = "Strumento %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink segnala solo lo strumento 1 sulle stampanti multistrumento. Inserisci il diametro dell'ugello di ogni strumento per mostrarli separatamente.";
 "content.metrics.filament_type.label"     = "Mostra tipo di filamento";
 "content.metrics.mmu.label"               = "Mostra MMU";
 "content.job_control.header"              = "Controllo stampa";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "Velocità";
 "dropdown.metrics.z_height"               = "Altezza Z";
 "dropdown.metrics.nozzle_diameter"        = "Diametro ugello";
+"dropdown.metrics.nozzle_diameter.tool"   = "Ugello strumento %lld";
 "dropdown.metrics.filament_type"          = "Filamento";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Attivato";

--- a/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "印刷速度を表示";
 "content.metrics.z_height.label"          = "Z軸高さを表示";
 "content.metrics.nozzle_diameter.label"   = "ノズル径を表示";
+"content.metrics.nozzle_setup.label"      = "ノズル構成";
+"content.metrics.nozzle_setup.automatic"  = "自動 (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld ツール";
+"content.metrics.nozzle_tool.label"       = "ツール %lld";
+"content.metrics.nozzle_setup.footer"     = "マルチツールプリンターでは、PrusaLink はツール1のノズルのみ報告します。各ツールのノズル径を入力すると個別に表示できます。";
 "content.metrics.filament_type.label"     = "フィラメントの種類を表示";
 "content.metrics.mmu.label"               = "MMUを表示";
 "content.job_control.header"              = "印刷制御";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "速度";
 "dropdown.metrics.z_height"               = "Z軸高さ";
 "dropdown.metrics.nozzle_diameter"        = "ノズル径";
+"dropdown.metrics.nozzle_diameter.tool"   = "ツール%lldのノズル";
 "dropdown.metrics.filament_type"          = "フィラメント";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "有効";

--- a/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/ja.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "開発者を応援する";
 "about.version"                           = "バージョン %@ (%@)";
+"about.diagnostics.title"                 = "サポート診断";
+"about.diagnostics.description"           = "プリンターの電源を入れ、アクセス可能にしてください。レポート作成前に API アクセスを確認します。";
+"about.diagnostics.copy"                  = "診断レポートをコピー";
+"about.diagnostics.checking"              = "プリンターを確認中…";
+"about.diagnostics.copied"                = "レポートをコピーしました。GitHub Issue に貼り付けてください。";
+"about.diagnostics.privacy"               = "レポートに API キー、アドレス、個人を特定する情報は含まれません。";
+"about.diagnostics.close"                 = "完了";
+"about.diagnostics.invalid_response"      = "プリンターから無効な診断応答が返されました。";
 
 // Footer
 "footer.preferences"                      = "環境設定";

--- a/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "Wesprzyj dewelopera";
 "about.version"                           = "Wersja %@ (%@)";
+"about.diagnostics.title"                 = "Diagnostyka pomocy";
+"about.diagnostics.description"           = "Drukarka musi być włączona i dostępna. Dostęp do API jest sprawdzany przed utworzeniem raportu.";
+"about.diagnostics.copy"                  = "Kopiuj raport diagnostyczny";
+"about.diagnostics.checking"              = "Sprawdzanie drukarki…";
+"about.diagnostics.copied"                = "Raport skopiowany. Wklej go do zgłoszenia GitHub.";
+"about.diagnostics.privacy"               = "Raport nigdy nie zawiera klucza API, adresu ani danych identyfikujących.";
+"about.diagnostics.close"                 = "Gotowe";
+"about.diagnostics.invalid_response"      = "Drukarka zwróciła nieprawidłową odpowiedź diagnostyczną.";
 
 // Footer
 "footer.preferences"                      = "Ustawienia";

--- a/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pl.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "Pokaż prędkość druku";
 "content.metrics.z_height.label"          = "Pokaż wysokość Z";
 "content.metrics.nozzle_diameter.label"   = "Pokaż średnicę dyszy";
+"content.metrics.nozzle_setup.label"      = "Konfiguracja dysz";
+"content.metrics.nozzle_setup.automatic"  = "Automatycznie (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld narzędzi";
+"content.metrics.nozzle_tool.label"       = "Narzędzie %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink zgłasza tylko narzędzie 1 w drukarkach wielonarzędziowych. Wprowadź średnicę dyszy każdego narzędzia, aby wyświetlać je oddzielnie.";
 "content.metrics.filament_type.label"     = "Pokaż typ filamentu";
 "content.metrics.mmu.label"               = "Pokaż MMU";
 "content.job_control.header"              = "Sterowanie drukiem";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "Prędkość";
 "dropdown.metrics.z_height"               = "Wysokość Z";
 "dropdown.metrics.nozzle_diameter"        = "Średnica dyszy";
+"dropdown.metrics.nozzle_diameter.tool"   = "Dysza narzędzia %lld";
 "dropdown.metrics.filament_type"          = "Filament";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Włączone";

--- a/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "Apoiar o desenvolvedor";
 "about.version"                           = "Versão %@ (%@)";
+"about.diagnostics.title"                 = "Diagnóstico de suporte";
+"about.diagnostics.description"           = "A impressora deve estar ligada e acessível. O acesso à API é verificado antes de criar o relatório.";
+"about.diagnostics.copy"                  = "Copiar relatório de diagnóstico";
+"about.diagnostics.checking"              = "Verificando a impressora…";
+"about.diagnostics.copied"                = "Relatório copiado. Cole-o em uma issue do GitHub.";
+"about.diagnostics.privacy"               = "O relatório nunca inclui sua chave de API, endereço ou identificadores pessoais.";
+"about.diagnostics.close"                 = "Concluído";
+"about.diagnostics.invalid_response"      = "A impressora retornou uma resposta de diagnóstico inválida.";
 
 // Footer
 "footer.preferences"                      = "Ajustes";

--- a/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/pt-BR.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "Mostrar velocidade de impressão";
 "content.metrics.z_height.label"          = "Mostrar altura Z";
 "content.metrics.nozzle_diameter.label"   = "Mostrar diâmetro do bico";
+"content.metrics.nozzle_setup.label"      = "Configuração dos bicos";
+"content.metrics.nozzle_setup.automatic"  = "Automático (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld ferramentas";
+"content.metrics.nozzle_tool.label"       = "Ferramenta %lld";
+"content.metrics.nozzle_setup.footer"     = "O PrusaLink informa apenas a ferramenta 1 em impressoras multiferramenta. Informe o diâmetro do bico de cada ferramenta para exibi-los separadamente.";
 "content.metrics.filament_type.label"     = "Mostrar tipo de filamento";
 "content.metrics.mmu.label"               = "Mostrar MMU";
 "content.job_control.header"              = "Controle de impressão";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "Velocidade";
 "dropdown.metrics.z_height"               = "Altura Z";
 "dropdown.metrics.nozzle_diameter"        = "Diâmetro do bico";
+"dropdown.metrics.nozzle_diameter.tool"   = "Bico da ferramenta %lld";
 "dropdown.metrics.filament_type"          = "Filamento";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "Ativado";

--- a/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -217,6 +217,14 @@
 // About additions
 "about.coffee_help"                       = "支持开发者";
 "about.version"                           = "版本 %@ (%@)";
+"about.diagnostics.title"                 = "支持诊断";
+"about.diagnostics.description"           = "打印机必须已开机且可访问。创建报告前会验证 API 访问权限。";
+"about.diagnostics.copy"                  = "复制诊断报告";
+"about.diagnostics.checking"              = "正在检查打印机…";
+"about.diagnostics.copied"                = "报告已复制。请粘贴到 GitHub Issue 中。";
+"about.diagnostics.privacy"               = "报告绝不会包含您的 API 密钥、地址或个人标识信息。";
+"about.diagnostics.close"                 = "完成";
+"about.diagnostics.invalid_response"      = "打印机返回了无效的诊断响应。";
 
 // Footer
 "footer.preferences"                      = "偏好设置";

--- a/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PrusaStatusBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -47,6 +47,11 @@
 "content.metrics.speed.label"             = "显示打印速度";
 "content.metrics.z_height.label"          = "显示 Z 轴高度";
 "content.metrics.nozzle_diameter.label"   = "显示喷嘴直径";
+"content.metrics.nozzle_setup.label"      = "喷嘴配置";
+"content.metrics.nozzle_setup.automatic"  = "自动 (PrusaLink)";
+"content.metrics.nozzle_setup.tools"      = "%lld 个工具";
+"content.metrics.nozzle_tool.label"       = "工具 %lld";
+"content.metrics.nozzle_setup.footer"     = "PrusaLink 在多工具打印机上仅报告工具 1。输入每个工具的喷嘴直径即可分别显示。";
 "content.metrics.filament_type.label"     = "显示耗材类型";
 "content.metrics.mmu.label"               = "显示 MMU";
 "content.job_control.header"              = "打印控制";
@@ -271,6 +276,7 @@
 "dropdown.metrics.speed"                  = "速度";
 "dropdown.metrics.z_height"               = "Z 轴高度";
 "dropdown.metrics.nozzle_diameter"        = "喷嘴直径";
+"dropdown.metrics.nozzle_diameter.tool"   = "工具 %lld 喷嘴";
 "dropdown.metrics.filament_type"          = "耗材";
 "dropdown.metrics.mmu"                    = "MMU";
 "dropdown.metrics.mmu.enabled"            = "已启用";

--- a/PrusaStatusBar/Services/CameraSnapshotProvider.swift
+++ b/PrusaStatusBar/Services/CameraSnapshotProvider.swift
@@ -102,7 +102,9 @@
                 }
                 try await Task.sleep(nanoseconds: 250_000_000)
             }
-            if let lastError { throw lastError }
+            if let lastError {
+                throw lastError
+            }
             throw CameraSnapshotError.badStatus(lastStatus)
         }
 

--- a/PrusaStatusBar/Services/Localization/L10n.swift
+++ b/PrusaStatusBar/Services/Localization/L10n.swift
@@ -67,7 +67,9 @@ public enum LocalizationBundle {
     }
 
     private static func loadedBundle(for code: LanguageCode) -> Bundle? {
-        if let cached = cache[code.rawValue] { return cached }
+        if let cached = cache[code.rawValue] {
+            return cached
+        }
         guard
             let path = Bundle.main.path(forResource: code.rawValue, ofType: "lproj"),
             let bundle = Bundle(path: path)

--- a/PrusaStatusBar/Services/MJPEGFrameGrabber.swift
+++ b/PrusaStatusBar/Services/MJPEGFrameGrabber.swift
@@ -46,8 +46,12 @@ enum MJPEGFrameGrabber {
         var soiIndex: Int?
 
         for try await byte in bytes {
-            if Date() >= deadline { throw GrabError.timeout }
-            if buffer.count >= maxBytes { throw GrabError.streamEnded }
+            if Date() >= deadline {
+                throw GrabError.timeout
+            }
+            if buffer.count >= maxBytes {
+                throw GrabError.streamEnded
+            }
 
             buffer.append(byte)
             let lastIndex = buffer.count - 1

--- a/PrusaStatusBar/Services/PrinterDiagnostics.swift
+++ b/PrusaStatusBar/Services/PrinterDiagnostics.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Sanitized, shareable responses collected from an authenticated printer.
+/// Raw response bytes never leave the network client.
+public struct PrinterDiagnosticSnapshot: Sendable, Equatable {
+    public let infoJSON: String
+    public let statusJSON: String
+    public let jobJSON: String?
+    public let versionJSON: String?
+    public let printerJSON: String?
+
+    init(info: Data, status: Data, job: Data?, version: Data?, printer: Data?) throws {
+        infoJSON = try Self.redactedJSON(from: info)
+        statusJSON = try Self.redactedJSON(from: status)
+        jobJSON = job.flatMap { try? Self.redactedJSON(from: $0) }
+        versionJSON = version.flatMap { try? Self.redactedJSON(from: $0) }
+        printerJSON = printer.flatMap { try? Self.redactedJSON(from: $0) }
+    }
+
+    func markdown(
+        showNozzleDiameter: Bool,
+        configuredNozzleDiameters: [Double],
+        effectiveNozzleDiameters: [Double]
+    ) -> String {
+        let version = AppVersion.shortString ?? "?"
+        let build = AppVersion.buildNumber ?? "?"
+        let generatedAt = ISO8601DateFormatter().string(from: Date())
+        let nozzleMode = if configuredNozzleDiameters.isEmpty {
+            "Automatic (PrusaLink)"
+        } else {
+            "Manual: " + Self.nozzleList(configuredNozzleDiameters)
+        }
+
+        return """
+        ## Prusa StatusBar diagnostic
+
+        - Generated: \(generatedAt)
+        - App: \(version) (\(build))
+        - macOS: \(ProcessInfo.processInfo.operatingSystemVersionString)
+        - Architecture: \(Self.architecture)
+        - Locale: \(Locale.current.identifier)
+        - Printer API access: Verified
+        - Nozzle diameter display: \(showNozzleDiameter ? "Enabled" : "Disabled")
+        - Nozzle configuration: \(nozzleMode)
+        - Effective nozzle diameters: \(Self.nozzleList(effectiveNozzleDiameters))
+
+        ### `GET /api/v1/info`
+
+        ```json
+        \(infoJSON)
+        ```
+
+        ### `GET /api/version`
+
+        \(Self.endpointSection(versionJSON))
+
+        ### `GET /api/v1/status`
+
+        ```json
+        \(statusJSON)
+        ```
+
+        ### `GET /api/printer`
+
+        \(Self.endpointSection(printerJSON))
+
+        ### `GET /api/v1/job`
+
+        \(Self.endpointSection(jobJSON, unavailable: "No active print job or endpoint unavailable."))
+        """
+    }
+
+    private static func endpointSection(
+        _ json: String?,
+        unavailable: String = "Endpoint unavailable on this firmware."
+    ) -> String {
+        guard let json else {
+            return "_\(unavailable)_"
+        }
+        return """
+        ```json
+        \(json)
+        ```
+        """
+    }
+
+    private static func nozzleList(_ diameters: [Double]) -> String {
+        guard !diameters.isEmpty else {
+            return "None"
+        }
+        return diameters.enumerated()
+            .map { "Tool \($0.offset + 1) \(String(format: "%.2f mm", $0.element))" }
+            .joined(separator: ", ")
+    }
+
+    private static var architecture: String {
+        #if arch(arm64)
+            "arm64"
+        #elseif arch(x86_64)
+            "x86_64"
+        #else
+            "unknown"
+        #endif
+    }
+
+    private static let sensitiveKeyFragments = [
+        "address", "apikey", "authorization", "cookie", "credential",
+        "displayname", "download", "hostname", "icon", "mac", "name",
+        "password", "path", "secret", "serial", "thumbnail", "token",
+        "uri", "url", "username", "uuid"
+    ]
+
+    private static func redactedJSON(from data: Data) throws -> String {
+        let object = try JSONSerialization.jsonObject(with: data)
+        let redacted = redact(object)
+        let output = try JSONSerialization.data(
+            withJSONObject: redacted,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+        guard let json = String(data: output, encoding: .utf8) else {
+            throw CocoaError(.fileReadInapplicableStringEncoding)
+        }
+        return json
+    }
+
+    private static func redact(_ value: Any) -> Any {
+        if let dictionary = value as? [String: Any] {
+            return dictionary.reduce(into: [String: Any]()) { result, item in
+                result[item.key] = isSensitiveKey(item.key) ? "[redacted]" : redact(item.value)
+            }
+        }
+        if let array = value as? [Any] {
+            return array.map(redact)
+        }
+        if let string = value as? String, containsAddress(string) {
+            return "[redacted]"
+        }
+        return value
+    }
+
+    private static func isSensitiveKey(_ key: String) -> Bool {
+        let normalized = key.lowercased().filter(\.isLetter)
+        return sensitiveKeyFragments.contains { normalized.contains($0) }
+    }
+
+    private static func containsAddress(_ value: String) -> Bool {
+        let patterns = [
+            #"(?i)\b(?:https?|rtsp)://"#,
+            #"\b(?:\d{1,3}\.){3}\d{1,3}\b"#,
+            #"(?i)\b(?:[0-9a-f]{2}:){5}[0-9a-f]{2}\b"#
+        ]
+        return patterns.contains { value.range(of: $0, options: .regularExpression) != nil }
+    }
+}
+
+public enum PrinterDiagnosticsError: Error, Equatable, Sendable {
+    case printer(PrusaLinkError)
+    case invalidResponse
+}

--- a/PrusaStatusBar/Services/PrusaLinkClient.swift
+++ b/PrusaStatusBar/Services/PrusaLinkClient.swift
@@ -8,6 +8,9 @@ public protocol PrusaLinkClient: Sendable {
     func fetchJob() async -> Result<PrintJob?, PrusaLinkError>
     func fetchThumbnail(at path: String) async -> Result<Data, PrusaLinkError>
     func fetchInfo() async -> Result<PrinterInfo, PrusaLinkError>
+    /// Collects sanitized raw API responses for a support report. Requires an
+    /// active or paused print so the current job can be inspected.
+    func fetchDiagnosticSnapshot() async -> Result<PrinterDiagnosticSnapshot, PrinterDiagnosticsError>
     /// Reads the OctoPrint-compatible `/api/printer` endpoint for the
     /// `telemetry.material` field. PrusaLink's own `/api/v1/status` does not
     /// surface the loaded filament material on most firmware (MK3.5, MK4,

--- a/PrusaStatusBar/Services/SemanticVersion.swift
+++ b/PrusaStatusBar/Services/SemanticVersion.swift
@@ -35,8 +35,12 @@ public struct SemanticVersion: Sendable, Equatable, Comparable {
     }
 
     public static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
-        if lhs.major != rhs.major { return lhs.major < rhs.major }
-        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major
+        }
+        if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor
+        }
         return lhs.patch < rhs.patch
     }
 }

--- a/PrusaStatusBar/Services/StatusPresenter.swift
+++ b/PrusaStatusBar/Services/StatusPresenter.swift
@@ -67,7 +67,9 @@ public enum StatusPresenter {
         isConfigured: Bool = true
     ) -> String {
         guard isConfigured else { return AssetName.idle }
-        if isDisconnected { return AssetName.disconnected }
+        if isDisconnected {
+            return AssetName.disconnected
+        }
         return switch state {
         case .printing: AssetName.printing
         case .paused: AssetName.paused

--- a/PrusaStatusBar/Services/StubPrusaLinkClient.swift
+++ b/PrusaStatusBar/Services/StubPrusaLinkClient.swift
@@ -56,6 +56,28 @@ public actor StubPrusaLinkClient: PrusaLinkClient {
         ))
     }
 
+    public func fetchDiagnosticSnapshot() async -> Result<PrinterDiagnosticSnapshot, PrinterDiagnosticsError> {
+        let info = Data(#"{"nozzle_diameter":0.4,"serial":"STUB-0001","hostname":"stub.local"}"#.utf8)
+        let status = Data(#"{"printer":{"state":"PRINTING","temp_nozzle":215}}"#.utf8)
+        let job: Data? = if case .idle = phase {
+            nil
+        } else {
+            Data(#"{"file":{"display_name":"Spice_Harvester.gcode","path":"/usb/Spice_Harvester.gcode"}}"#.utf8)
+        }
+        let version = Data(#"{"firmware":"6.4.2","printer":"17.0.0"}"#.utf8)
+        let printer = Data(#"{"telemetry":{"material":"PLA"},"state":{"text":"Printing"}}"#.utf8)
+        return Result {
+            try PrinterDiagnosticSnapshot(
+                info: info,
+                status: status,
+                job: job,
+                version: version,
+                printer: printer
+            )
+        }
+        .mapError { _ in .invalidResponse }
+    }
+
     public func fetchLegacyMaterial() async -> Result<String?, PrusaLinkError> {
         switch phase {
         case .printing, .attention:

--- a/PrusaStatusBar/Services/URLSessionPrusaLinkClient+Diagnostics.swift
+++ b/PrusaStatusBar/Services/URLSessionPrusaLinkClient+Diagnostics.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+extension URLSessionPrusaLinkClient {
+    public func fetchDiagnosticSnapshot() async -> Result<PrinterDiagnosticSnapshot, PrinterDiagnosticsError> {
+        let statusResponse: DiagnosticResponse
+        switch await fetchDiagnosticResponse(path: "/api/v1/status") {
+        case let .success(response):
+            statusResponse = response
+        case let .failure(error):
+            return .failure(.printer(error))
+        }
+
+        let infoResponse: DiagnosticResponse
+        switch await fetchDiagnosticResponse(path: "/api/v1/info") {
+        case let .success(response):
+            infoResponse = response
+        case let .failure(error):
+            return .failure(.printer(error))
+        }
+
+        let versionData = await fetchOptionalDiagnosticData(path: "/api/version")
+        let printerData = await fetchOptionalDiagnosticData(path: "/api/printer")
+        let jobData = await fetchOptionalDiagnosticData(path: "/api/v1/job")
+
+        do {
+            return try .success(PrinterDiagnosticSnapshot(
+                info: infoResponse.data,
+                status: statusResponse.data,
+                job: jobData,
+                version: versionData,
+                printer: printerData
+            ))
+        } catch {
+            return .failure(.invalidResponse)
+        }
+    }
+
+    private func fetchDiagnosticResponse(path: String) async -> Result<DiagnosticResponse, PrusaLinkError> {
+        await perform(path: path) { status, data in
+            guard (200 ... 299).contains(status) else {
+                return .failure(.server(status: status))
+            }
+            return .success(DiagnosticResponse(status: status, data: data))
+        }
+    }
+
+    private func fetchOptionalDiagnosticData(path: String) async -> Data? {
+        guard case let .success(response) = await fetchDiagnosticResponse(path: path),
+              response.status != 204,
+              !response.data.isEmpty
+        else {
+            return nil
+        }
+        return response.data
+    }
+}
+
+private struct DiagnosticResponse: Sendable {
+    let status: Int
+    let data: Data
+}

--- a/PrusaStatusBar/Services/URLSessionPrusaLinkClient.swift
+++ b/PrusaStatusBar/Services/URLSessionPrusaLinkClient.swift
@@ -177,7 +177,7 @@ public final class URLSessionPrusaLinkClient: PrusaLinkClient, @unchecked Sendab
     /// returns `.unreachable`, the request is retried once against the
     /// alternate URL. Retry is gated to `.unreachable` so a 401/404/5xx
     /// from one URL is not silently re-tried against the other.
-    private func perform<T>(
+    func perform<T>(
         path: String,
         method: String = "GET",
         decode: (_ status: Int, _ data: Data) -> Result<T, PrusaLinkError>

--- a/PrusaStatusBar/Services/UserPreferences+Nozzles.swift
+++ b/PrusaStatusBar/Services/UserPreferences+Nozzles.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+extension UserPreferences {
+    /// Manual per-tool diameters for multi-tool printers. An empty array keeps
+    /// the existing automatic behavior and displays `/api/v1/info`'s single
+    /// `nozzle_diameter` value. PrusaLink currently exposes only Tool 1, so
+    /// multi-tool configurations are explicit user input.
+    public var configuredNozzleDiameters: [Double] {
+        get {
+            guard let stored = defaultsAccess.array(forKey: UserPreferencesKey.configuredNozzleDiameters) else {
+                return []
+            }
+            let values = stored.compactMap { ($0 as? NSNumber)?.doubleValue }
+                .filter(\.isFinite)
+                .prefix(Self.nozzleToolCountMax)
+                .map(Self.clampedNozzleDiameter)
+            return values.count >= 2 ? values : []
+        }
+        set {
+            let values = newValue.filter(\.isFinite)
+                .prefix(Self.nozzleToolCountMax)
+                .map(Self.clampedNozzleDiameter)
+            if values.count >= 2 {
+                defaultsAccess.set(values, forKey: UserPreferencesKey.configuredNozzleDiameters)
+            } else {
+                defaultsAccess.removeObject(forKey: UserPreferencesKey.configuredNozzleDiameters)
+            }
+        }
+    }
+
+    private static func clampedNozzleDiameter(_ value: Double) -> Double {
+        max(nozzleDiameterMin, min(nozzleDiameterMax, value))
+    }
+}

--- a/PrusaStatusBar/Services/UserPreferences.swift
+++ b/PrusaStatusBar/Services/UserPreferences.swift
@@ -19,6 +19,7 @@ enum UserPreferencesKey {
     static let showSpeed = "showSpeed"
     static let showZHeight = "showZHeight"
     static let showNozzleDiameter = "showNozzleDiameter"
+    static let configuredNozzleDiameters = "configuredNozzleDiameters"
     static let showFilamentType = "showFilamentType"
     static let showMMU = "showMMU"
     static let showTemperatures = "showTemperatures"
@@ -86,6 +87,12 @@ public final class UserPreferences: @unchecked Sendable {
     public static let disconnectedRefreshIntervalDefault = 300
     public static let disconnectedRefreshIntervalMin = 5
     public static let disconnectedRefreshIntervalMax = 3600
+
+    public static let nozzleDiameterDefault = 0.4
+    public static let nozzleDiameterMin = 0.1
+    public static let nozzleDiameterMax = 1.8
+    /// Covers XL (up to 5 tools) and INDX (up to 8 tools).
+    public static let nozzleToolCountMax = 8
 
     private let defaults: UserDefaults
 

--- a/PrusaStatusBar/UI/AboutTab.swift
+++ b/PrusaStatusBar/UI/AboutTab.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
 struct AboutTab: View {
+    @Bindable var model: AppModel
+    let services: AppServices
+
+    @State private var isShowingDiagnostics = false
+
     var body: some View {
         VStack(spacing: Theme.Spacing.lrg) {
             Spacer(minLength: Theme.Spacing.lrg)
@@ -59,6 +64,12 @@ struct AboutTab: View {
                 }
             }
 
+            Button {
+                isShowingDiagnostics = true
+            } label: {
+                Label(L10n.t("about.diagnostics.title"), systemImage: "stethoscope")
+            }
+
             Spacer()
 
             VStack(spacing: 4) {
@@ -85,6 +96,11 @@ struct AboutTab: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()
+        .sheet(isPresented: $isShowingDiagnostics) {
+            SupportDiagnosticsSheet(model: model, services: services) {
+                isShowingDiagnostics = false
+            }
+        }
     }
 
     private var versionString: String {

--- a/PrusaStatusBar/UI/Components/CameraPlayer.swift
+++ b/PrusaStatusBar/UI/Components/CameraPlayer.swift
@@ -246,7 +246,9 @@
                     try? await Task.sleep(nanoseconds: 100_000_000)
                     guard let self, !Task.isCancelled else { return }
                     checkReady()
-                    if hasReportedReady { return }
+                    if hasReportedReady {
+                        return
+                    }
                 }
             }
         }

--- a/PrusaStatusBar/UI/Components/CameraTile.swift
+++ b/PrusaStatusBar/UI/Components/CameraTile.swift
@@ -204,7 +204,9 @@ struct CameraTileHeightPreference: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         let next = nextValue()
-        if next > 0 { value = next }
+        if next > 0 {
+            value = next
+        }
     }
 }
 
@@ -215,7 +217,9 @@ struct CameraTileWidthPreference: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         let next = nextValue()
-        if next > 0 { value = next }
+        if next > 0 {
+            value = next
+        }
     }
 }
 
@@ -227,7 +231,9 @@ struct CameraTileWidthPreference: PreferenceKey {
 enum CameraTileSizeCache {
     static func commit(model: AppModel, kind: CameraTileKind, height: CGFloat) {
         guard height > 0 else { return }
-        if model.cameraTileHeights[kind] == height { return }
+        if model.cameraTileHeights[kind] == height {
+            return
+        }
         model.cameraTileHeights[kind] = height
     }
 }

--- a/PrusaStatusBar/UI/Components/CustomActionIconButton.swift
+++ b/PrusaStatusBar/UI/Components/CustomActionIconButton.swift
@@ -26,13 +26,11 @@ struct CustomActionIconButton: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        Group {
-            if isVisible {
-                visibleButton
-            } else {
-                Color.clear
-                    .frame(width: 32, height: 28)
-            }
+        if isVisible {
+            visibleButton
+        } else {
+            Color.clear
+                .frame(width: 32, height: 28)
         }
     }
 

--- a/PrusaStatusBar/UI/Components/CustomActionSlotCard.swift
+++ b/PrusaStatusBar/UI/Components/CustomActionSlotCard.swift
@@ -122,10 +122,16 @@ struct CustomActionSlotCard: View {
 
     private var enableBlockedReason: String {
         var items: [String] = []
-        if !hasURL { items.append(L10n.t("prefs.actions.toggle.requirement.url")) }
+        if !hasURL {
+            items.append(L10n.t("prefs.actions.toggle.requirement.url"))
+        }
         if slot.isHeader {
-            if !hasSymbol { items.append(L10n.t("prefs.actions.toggle.requirement.icon")) }
-            if !hasName { items.append(L10n.t("prefs.actions.toggle.requirement.name")) }
+            if !hasSymbol {
+                items.append(L10n.t("prefs.actions.toggle.requirement.icon"))
+            }
+            if !hasName {
+                items.append(L10n.t("prefs.actions.toggle.requirement.name"))
+            }
         } else if !hasSymbol, !hasName {
             items.append(L10n.t("prefs.actions.toggle.requirement.name_or_icon"))
         }

--- a/PrusaStatusBar/UI/Components/FieldValidationCaption.swift
+++ b/PrusaStatusBar/UI/Components/FieldValidationCaption.swift
@@ -8,7 +8,9 @@ enum FieldValidationState: Equatable {
     case invalid(String)
 
     var isValid: Bool {
-        if case .valid = self { return true }
+        if case .valid = self {
+            return true
+        }
         return false
     }
 }

--- a/PrusaStatusBar/UI/Components/GenericCameraTile.swift
+++ b/PrusaStatusBar/UI/Components/GenericCameraTile.swift
@@ -141,8 +141,12 @@ struct GenericCameraTile: View {
         }
 
         private var shouldRenderStream: Bool {
-            if fallbackToStill, config.resolvedStillImageURL() != nil { return false }
-            if case .stream = config.preferredMode { return true }
+            if fallbackToStill, config.resolvedStillImageURL() != nil {
+                return false
+            }
+            if case .stream = config.preferredMode {
+                return true
+            }
             return false
         }
 

--- a/PrusaStatusBar/UI/Components/JobCard.swift
+++ b/PrusaStatusBar/UI/Components/JobCard.swift
@@ -210,29 +210,28 @@ struct JobCard: View {
         return StatusPresenter.formatEtaPill(eta: eta)
     }
 
+    @ViewBuilder
     private var thumbnailView: some View {
-        Group {
-            if let image = nsImage {
-                Image(nsImage: image)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: Theme.Layout.heroThumbnail, height: Theme.Layout.heroThumbnail)
-                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
-                            .strokeBorder(Theme.Palette.hairline, lineWidth: Theme.Hairline.width)
-                    )
-            } else {
-                RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
-                    .fill(Theme.Palette.brandMuted(accent, customHex: customHex))
-                    .frame(width: Theme.Layout.heroThumbnail, height: Theme.Layout.heroThumbnail)
-                    .overlay(
-                        Image(systemName: "cube")
-                            .font(.system(size: 24, weight: .ultraLight))
-                            .symbolRenderingMode(.hierarchical)
-                            .foregroundStyle(Theme.Palette.brand(accent, customHex: customHex))
-                    )
-            }
+        if let image = nsImage {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: Theme.Layout.heroThumbnail, height: Theme.Layout.heroThumbnail)
+                .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+                        .strokeBorder(Theme.Palette.hairline, lineWidth: Theme.Hairline.width)
+                )
+        } else {
+            RoundedRectangle(cornerRadius: Theme.Radius.thumbnail, style: .continuous)
+                .fill(Theme.Palette.brandMuted(accent, customHex: customHex))
+                .frame(width: Theme.Layout.heroThumbnail, height: Theme.Layout.heroThumbnail)
+                .overlay(
+                    Image(systemName: "cube")
+                        .font(.system(size: 24, weight: .ultraLight))
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundStyle(Theme.Palette.brand(accent, customHex: customHex))
+                )
         }
     }
 

--- a/PrusaStatusBar/UI/Components/PlainBorderedTextField.swift
+++ b/PrusaStatusBar/UI/Components/PlainBorderedTextField.swift
@@ -15,24 +15,22 @@ struct PlainBorderedTextField: View {
     var monospaced: Bool = true
 
     var body: some View {
-        Group {
-            if isSecure {
-                PlainBorderedNSTextField(
-                    placeholder: placeholder,
-                    text: $text,
-                    isSecure: true,
-                    monospaced: monospaced
-                )
-                .id("secure")
-            } else {
-                PlainBorderedNSTextField(
-                    placeholder: placeholder,
-                    text: $text,
-                    isSecure: false,
-                    monospaced: monospaced
-                )
-                .id("plain")
-            }
+        if isSecure {
+            PlainBorderedNSTextField(
+                placeholder: placeholder,
+                text: $text,
+                isSecure: true,
+                monospaced: monospaced
+            )
+            .id("secure")
+        } else {
+            PlainBorderedNSTextField(
+                placeholder: placeholder,
+                text: $text,
+                isSecure: false,
+                monospaced: monospaced
+            )
+            .id("plain")
         }
     }
 }

--- a/PrusaStatusBar/UI/Components/RefreshIntervalEditor.swift
+++ b/PrusaStatusBar/UI/Components/RefreshIntervalEditor.swift
@@ -80,7 +80,9 @@ struct RefreshIntervalEditor: View {
                     .padding(.horizontal, 6)
                     .onSubmit { commitCustom() }
                     .onChange(of: customFieldFocused) { _, isFocused in
-                        if !isFocused { commitCustom() }
+                        if !isFocused {
+                            commitCustom()
+                        }
                     }
                 #if os(macOS)
                     .onExitCommand { commitCustom() }

--- a/PrusaStatusBar/UI/Components/SpoolIntervalSlider.swift
+++ b/PrusaStatusBar/UI/Components/SpoolIntervalSlider.swift
@@ -62,7 +62,9 @@ struct SpoolIntervalSlider: View {
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
-                        if !isDragging { isDragging = true }
+                        if !isDragging {
+                            isDragging = true
+                        }
                         handleDrag(value: value, usableWidth: usable)
                     }
                     .onEnded { _ in

--- a/PrusaStatusBar/UI/Components/StatusPill.swift
+++ b/PrusaStatusBar/UI/Components/StatusPill.swift
@@ -68,8 +68,12 @@ struct StatusPill: View {
     }
 
     private var label: String {
-        if unconfigured { return L10n.t("status.unconfigured") }
-        if disconnected { return L10n.t("status.disconnected") }
+        if unconfigured {
+            return L10n.t("status.unconfigured")
+        }
+        if disconnected {
+            return L10n.t("status.disconnected")
+        }
         return switch state {
         case .idle: L10n.t("status.idle")
         case .ready: L10n.t("status.ready")
@@ -84,8 +88,12 @@ struct StatusPill: View {
     }
 
     private var foreground: Color {
-        if unconfigured { return Theme.Palette.stateNeutral }
-        if disconnected { return Theme.Palette.stateNeutral }
+        if unconfigured {
+            return Theme.Palette.stateNeutral
+        }
+        if disconnected {
+            return Theme.Palette.stateNeutral
+        }
         return switch state {
         case .printing: Theme.Palette.statePrintingOrange
         case .paused: Theme.Palette.stateYellow
@@ -99,7 +107,9 @@ struct StatusPill: View {
     }
 
     private var background: Color {
-        if unconfigured || disconnected { return Theme.Palette.stateNeutral.opacity(0.14) }
+        if unconfigured || disconnected {
+            return Theme.Palette.stateNeutral.opacity(0.14)
+        }
         return switch state {
         case .printing: Theme.Palette.statePrintingOrangeMuted
         case .paused: Theme.Palette.stateYellow.opacity(0.14)

--- a/PrusaStatusBar/UI/Components/StillImagePollerView.swift
+++ b/PrusaStatusBar/UI/Components/StillImagePollerView.swift
@@ -67,7 +67,9 @@ import SwiftUI
                     image = nsImage
                     lastError = nil
                 case let .failure(reason):
-                    if image == nil { lastError = reason }
+                    if image == nil {
+                        lastError = reason
+                    }
                 }
             }
             fetcher = new

--- a/PrusaStatusBar/UI/CustomActionsSection.swift
+++ b/PrusaStatusBar/UI/CustomActionsSection.swift
@@ -60,7 +60,9 @@ struct CustomActionsSection: View {
         saveTask?.cancel()
         saveTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 500_000_000)
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             persistImmediately()
         }
     }

--- a/PrusaStatusBar/UI/DetachedStatusWindowController.swift
+++ b/PrusaStatusBar/UI/DetachedStatusWindowController.swift
@@ -93,7 +93,9 @@ final class DetachedStatusWindowController: NSObject, NSWindowDelegate {
                 if delay > 0 {
                     try? await Task.sleep(nanoseconds: delay * 1_000_000)
                 }
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    return
+                }
                 guard let self, let w = window, host === hosting else { return }
                 let fitted = hosting.sizeThatFits(in: NSSize(width: 360, height: 10000))
                 guard fitted.height > 50 else { continue }

--- a/PrusaStatusBar/UI/DropdownView.swift
+++ b/PrusaStatusBar/UI/DropdownView.swift
@@ -174,9 +174,15 @@ struct DropdownView: View {
     }
 
     private var presentation: Presentation {
-        if !model.isConfigured { return .unconfigured }
-        if model.isDisconnected { return .disconnected }
-        if let status = model.lastStatus { return .content(status) }
+        if !model.isConfigured {
+            return .unconfigured
+        }
+        if model.isDisconnected {
+            return .disconnected
+        }
+        if let status = model.lastStatus {
+            return .content(status)
+        }
         return .loading
     }
 
@@ -207,49 +213,6 @@ struct DropdownView: View {
                 TempCard(heater: .bed, temperature: bed)
             }
         }
-    }
-
-    private func extraRows(for status: PrinterStatus) -> [LiveMetricsCard.Row] {
-        var rows: [LiveMetricsCard.Row] = []
-        if model.showNozzleDiameter, let diameter = model.printerInfo?.nozzleDiameter {
-            rows.append(.init(
-                symbol: "circle.dotted",
-                label: L10n.t("dropdown.metrics.nozzle_diameter"),
-                value: String(format: "%.2f mm", diameter)
-            ))
-        }
-        if model.showFilamentType, let material = status.activeFilamentMaterial {
-            rows.append(.init(
-                symbol: "drop.fill",
-                label: L10n.t("dropdown.metrics.filament_type"),
-                value: material
-            ))
-        }
-        if model.showSpeed, let speed = status.speed {
-            rows.append(.init(
-                symbol: "gauge.medium",
-                label: L10n.t("dropdown.metrics.speed"),
-                value: "\(Int(speed.rounded()))%"
-            ))
-        }
-        if model.showZHeight, let zHeight = status.zHeight {
-            rows.append(.init(
-                symbol: "arrow.up.and.down",
-                label: L10n.t("dropdown.metrics.z_height"),
-                value: String(format: "%.2f mm", zHeight)
-            ))
-        }
-        if model.showMMU, let mmuEnabled = model.printerInfo?.mmuEnabled {
-            let valueKey = mmuEnabled
-                ? "dropdown.metrics.mmu.enabled"
-                : "dropdown.metrics.mmu.disabled"
-            rows.append(.init(
-                symbol: "square.stack.3d.up",
-                label: L10n.t("dropdown.metrics.mmu"),
-                value: L10n.t(valueKey)
-            ))
-        }
-        return rows
     }
 
     /// Returns the `PrinterState` used to drive the Actions section, or
@@ -316,6 +279,55 @@ struct DropdownView: View {
 }
 
 extension DropdownView {
+    private func extraRows(for status: PrinterStatus) -> [LiveMetricsCard.Row] {
+        var rows: [LiveMetricsCard.Row] = []
+        if model.showNozzleDiameter {
+            let diameters = model.effectiveNozzleDiameters
+            for (index, diameter) in diameters.enumerated() {
+                let label = diameters.count == 1
+                    ? L10n.t("dropdown.metrics.nozzle_diameter")
+                    : L10n.t("dropdown.metrics.nozzle_diameter.tool", Int64(index + 1))
+                rows.append(.init(
+                    symbol: "circle.dotted",
+                    label: label,
+                    value: String(format: "%.2f mm", diameter)
+                ))
+            }
+        }
+        if model.showFilamentType, let material = status.activeFilamentMaterial {
+            rows.append(.init(
+                symbol: "drop.fill",
+                label: L10n.t("dropdown.metrics.filament_type"),
+                value: material
+            ))
+        }
+        if model.showSpeed, let speed = status.speed {
+            rows.append(.init(
+                symbol: "gauge.medium",
+                label: L10n.t("dropdown.metrics.speed"),
+                value: "\(Int(speed.rounded()))%"
+            ))
+        }
+        if model.showZHeight, let zHeight = status.zHeight {
+            rows.append(.init(
+                symbol: "arrow.up.and.down",
+                label: L10n.t("dropdown.metrics.z_height"),
+                value: String(format: "%.2f mm", zHeight)
+            ))
+        }
+        if model.showMMU, let mmuEnabled = model.printerInfo?.mmuEnabled {
+            let valueKey = mmuEnabled
+                ? "dropdown.metrics.mmu.enabled"
+                : "dropdown.metrics.mmu.disabled"
+            rows.append(.init(
+                symbol: "square.stack.3d.up",
+                label: L10n.t("dropdown.metrics.mmu"),
+                value: L10n.t(valueKey)
+            ))
+        }
+        return rows
+    }
+
     /// Resolves the URL the PrusaConnect button should open. With a non-empty
     /// trimmed UUID, deep-links to the printer's dashboard; otherwise falls
     /// back to the generic cloud entry point. Carved out as `nonisolated`

--- a/PrusaStatusBar/UI/MenuContentTab+Nozzles.swift
+++ b/PrusaStatusBar/UI/MenuContentTab+Nozzles.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Keeps the multi-tool editor out of `MenuContentTab`'s general preference
+/// bindings and under SwiftLint's `type_body_length` budget.
+extension MenuContentTab {
+    var nozzleToolCountBinding: Binding<Int> {
+        Binding(
+            get: { model.configuredNozzleDiameters.count },
+            set: { newCount in
+                guard newCount >= 2 else {
+                    saveConfiguredNozzleDiameters([])
+                    return
+                }
+                var values = model.configuredNozzleDiameters
+                let seed = values.last
+                    ?? model.printerInfo?.nozzleDiameter
+                    ?? UserPreferences.nozzleDiameterDefault
+                if values.count < newCount {
+                    values.append(contentsOf: repeatElement(seed, count: newCount - values.count))
+                } else {
+                    values.removeLast(values.count - newCount)
+                }
+                saveConfiguredNozzleDiameters(values)
+            }
+        )
+    }
+
+    func nozzleDiameterBinding(at index: Int) -> Binding<Double> {
+        Binding(
+            get: {
+                guard model.configuredNozzleDiameters.indices.contains(index) else {
+                    return UserPreferences.nozzleDiameterDefault
+                }
+                return model.configuredNozzleDiameters[index]
+            },
+            set: { newValue in
+                guard model.configuredNozzleDiameters.indices.contains(index) else { return }
+                var values = model.configuredNozzleDiameters
+                values[index] = newValue
+                saveConfiguredNozzleDiameters(values)
+            }
+        )
+    }
+
+    private func saveConfiguredNozzleDiameters(_ values: [Double]) {
+        services.settings.configuredNozzleDiameters = values
+        model.configuredNozzleDiameters = services.settings.configuredNozzleDiameters
+    }
+}

--- a/PrusaStatusBar/UI/MenuContentTab.swift
+++ b/PrusaStatusBar/UI/MenuContentTab.swift
@@ -30,6 +30,31 @@ struct MenuContentTab: View {
                 Toggle(isOn: showNozzleDiameterBinding) {
                     Label(L10n.t("content.metrics.nozzle_diameter.label"), systemImage: "circle.dotted")
                 }
+                if model.showNozzleDiameter {
+                    Picker(selection: nozzleToolCountBinding) {
+                        Text(L10n.t("content.metrics.nozzle_setup.automatic")).tag(0)
+                        ForEach(2 ... UserPreferences.nozzleToolCountMax, id: \.self) { count in
+                            Text(L10n.t("content.metrics.nozzle_setup.tools", Int64(count))).tag(count)
+                        }
+                    } label: {
+                        Label(L10n.t("content.metrics.nozzle_setup.label"), systemImage: "wrench.adjustable")
+                    }
+                    ForEach(model.configuredNozzleDiameters.indices, id: \.self) { index in
+                        Stepper(
+                            value: nozzleDiameterBinding(at: index),
+                            in: UserPreferences.nozzleDiameterMin ... UserPreferences.nozzleDiameterMax,
+                            step: 0.05
+                        ) {
+                            HStack {
+                                Text(L10n.t("content.metrics.nozzle_tool.label", Int64(index + 1)))
+                                Spacer()
+                                Text(String(format: "%.2f mm", model.configuredNozzleDiameters[index]))
+                                    .font(.prusaBody.monospacedDigit())
+                                    .foregroundStyle(Theme.Palette.textSecondary)
+                            }
+                        }
+                    }
+                }
                 Toggle(isOn: showFilamentTypeBinding) {
                     Label(L10n.t("content.metrics.filament_type.label"), systemImage: "drop.fill")
                 }
@@ -45,7 +70,12 @@ struct MenuContentTab: View {
             } header: {
                 Text(L10n.t("content.metrics.header"))
             } footer: {
-                FormFooterText(L10n.t("content.metrics.footer"))
+                VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                    FormFooterText(L10n.t("content.metrics.footer"))
+                    if model.showNozzleDiameter, !model.configuredNozzleDiameters.isEmpty {
+                        FormFooterText(L10n.t("content.metrics.nozzle_setup.footer"))
+                    }
+                }
             }
 
             Section {
@@ -88,7 +118,9 @@ struct MenuContentTab: View {
         .onAppear { reloadFromStorage() }
         .onDisappear {
             saveTask?.cancel()
-            if hasUUIDChange { savePrusaConnectUUID() }
+            if hasUUIDChange {
+                savePrusaConnectUUID()
+            }
         }
         .onChange(of: prusaConnectUUID) { _, _ in scheduleAutoSave() }
     }
@@ -106,13 +138,19 @@ struct MenuContentTab: View {
     }
 
     private func scheduleAutoSave() {
-        if isReloading { return }
+        if isReloading {
+            return
+        }
         saveTask?.cancel()
         saveTask = Task {
             try? await Task.sleep(nanoseconds: 600_000_000)
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             await MainActor.run {
-                if hasUUIDChange { savePrusaConnectUUID() }
+                if hasUUIDChange {
+                    savePrusaConnectUUID()
+                }
             }
         }
     }

--- a/PrusaStatusBar/UI/PreferencesWindow.swift
+++ b/PrusaStatusBar/UI/PreferencesWindow.swift
@@ -145,7 +145,7 @@ struct PreferencesView: View {
             case .printer:
                 PrinterTab(model: model, services: services)
             case .about:
-                AboutTab()
+                AboutTab(model: model, services: services)
             }
         }
         .frame(minWidth: 560, minHeight: 620)

--- a/PrusaStatusBar/UI/PrinterTab.swift
+++ b/PrusaStatusBar/UI/PrinterTab.swift
@@ -85,7 +85,9 @@ struct PrinterTab: View {
         .onAppear { reloadFromStorage() }
         .onDisappear {
             saveTask?.cancel()
-            if hasChanges { save() }
+            if hasChanges {
+                save()
+            }
         }
         .onChange(of: url) { _, _ in scheduleAutoSave() }
         .onChange(of: fallbackURL) { _, _ in scheduleAutoSave() }
@@ -132,7 +134,9 @@ struct PrinterTab: View {
 
     private var cameraHostValidation: FieldValidationState {
         let trimmed = cameraHost.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return .empty }
+        if trimmed.isEmpty {
+            return .empty
+        }
         switch BuddyCameraHostDeriver.rtspURL(forHost: cameraHost) {
         case .success: return .valid
         case .failure(.empty): return .empty
@@ -202,7 +206,9 @@ struct PrinterTab: View {
 
     private var derivedRTSPForSave: String {
         let trimmed = cameraHost.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return "" }
+        if trimmed.isEmpty {
+            return ""
+        }
         switch BuddyCameraHostDeriver.rtspURL(forHost: cameraHost) {
         case let .success(url): return url.absoluteString
         case .failure: return services.settings.rtspURL ?? ""
@@ -275,13 +281,19 @@ private extension PrinterTab {
     /// repopulating @State, and short-circuited when nothing actually
     /// changed against persisted values.
     private func scheduleAutoSave() {
-        if isReloading { return }
+        if isReloading {
+            return
+        }
         saveTask?.cancel()
         saveTask = Task {
             try? await Task.sleep(nanoseconds: 600_000_000)
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             await MainActor.run {
-                if hasChanges { save() }
+                if hasChanges {
+                    save()
+                }
             }
         }
     }

--- a/PrusaStatusBar/UI/PrintingIconAnimator.swift
+++ b/PrusaStatusBar/UI/PrintingIconAnimator.swift
@@ -70,11 +70,15 @@ public final class PrintingIconAnimator {
 
         task = Task { @MainActor [weak self] in
             for frame in frames {
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    return
+                }
                 weakButton.value?.image = frame
                 try? await Task.sleep(nanoseconds: intervalNanos)
             }
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             weakButton.value?.image = settled
             completion()
             self?.task = nil

--- a/PrusaStatusBar/UI/SupportDiagnosticsSheet.swift
+++ b/PrusaStatusBar/UI/SupportDiagnosticsSheet.swift
@@ -1,0 +1,143 @@
+import AppKit
+import SwiftUI
+
+struct SupportDiagnosticsSheet: View {
+    @Bindable var model: AppModel
+    let services: AppServices
+    let onClose: () -> Void
+
+    @State private var state: DiagnosticsState = .idle
+
+    init(model: AppModel, services: AppServices, onClose: @escaping () -> Void) {
+        self.model = model
+        self.services = services
+        self.onClose = onClose
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: Theme.Spacing.med) {
+                Image(systemName: "stethoscope")
+                    .font(.system(size: 24, weight: .medium))
+                    .foregroundStyle(Theme.Palette.statePrintingOrange)
+                    .frame(width: 40, height: 40)
+                    .background(Theme.Palette.statePrintingOrangeMuted, in: Circle())
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                    Text(L10n.t("about.diagnostics.title"))
+                        .font(.prusaTitle)
+                    Text(L10n.t("about.diagnostics.description"))
+                        .font(.prusaCaption)
+                        .foregroundStyle(Theme.Palette.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer()
+            }
+            .padding(Theme.Spacing.xlg)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.med) {
+                Label(L10n.t("about.diagnostics.privacy"), systemImage: "lock.shield")
+                    .font(.prusaCaption)
+                    .foregroundStyle(Theme.Palette.textSecondary)
+
+                if let message = diagnosticsStatusMessage {
+                    Label(message, systemImage: diagnosticsStatusSymbol)
+                        .font(.prusaCaption)
+                        .foregroundStyle(diagnosticsStatusColor)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Theme.Spacing.xlg)
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(L10n.t("about.diagnostics.close"), action: onClose)
+                Button(
+                    action: { Task { await copyDiagnostics() } },
+                    label: {
+                        HStack(spacing: Theme.Spacing.sml) {
+                            if state == .checking {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "doc.on.clipboard")
+                            }
+                            Text(state == .checking
+                                ? L10n.t("about.diagnostics.checking")
+                                : L10n.t("about.diagnostics.copy"))
+                        }
+                    }
+                )
+                .keyboardShortcut(.defaultAction)
+                .disabled(state == .checking)
+            }
+            .padding(Theme.Spacing.lrg)
+        }
+        .frame(width: 480)
+        .background(Theme.Palette.surfaceElevated)
+    }
+
+    @MainActor
+    private func copyDiagnostics() async {
+        state = .checking
+        switch await services.client.fetchDiagnosticSnapshot() {
+        case let .success(snapshot):
+            let report = snapshot.markdown(
+                showNozzleDiameter: model.showNozzleDiameter,
+                configuredNozzleDiameters: model.configuredNozzleDiameters,
+                effectiveNozzleDiameters: model.effectiveNozzleDiameters
+            )
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(report, forType: .string)
+            state = .copied
+        case let .failure(error):
+            state = .failed(diagnosticsMessage(for: error))
+        }
+    }
+
+    private func diagnosticsMessage(for error: PrinterDiagnosticsError) -> String {
+        switch error {
+        case let .printer(error):
+            error.localizedUserDescription
+        case .invalidResponse:
+            L10n.t("about.diagnostics.invalid_response")
+        }
+    }
+
+    private var diagnosticsStatusMessage: String? {
+        switch state {
+        case .idle, .checking:
+            nil
+        case .copied:
+            L10n.t("about.diagnostics.copied")
+        case let .failed(error):
+            error
+        }
+    }
+
+    private var diagnosticsStatusSymbol: String {
+        if case .copied = state {
+            return "checkmark.circle.fill"
+        }
+        return "exclamationmark.triangle.fill"
+    }
+
+    private var diagnosticsStatusColor: Color {
+        if case .copied = state {
+            return Theme.Palette.stateGreen
+        }
+        return Theme.Palette.stateRed
+    }
+}
+
+private enum DiagnosticsState: Equatable {
+    case idle
+    case checking
+    case copied
+    case failed(String)
+}

--- a/PrusaStatusBarTests/CustomActionRunnerTests.swift
+++ b/PrusaStatusBarTests/CustomActionRunnerTests.swift
@@ -190,7 +190,9 @@ private extension InputStream {
         var buffer = [UInt8](repeating: 0, count: bufferSize)
         while hasBytesAvailable {
             let read = read(&buffer, maxLength: bufferSize)
-            if read <= 0 { break }
+            if read <= 0 {
+                break
+            }
             data.append(buffer, count: read)
         }
         return data

--- a/PrusaStatusBarTests/PrinterDiagnosticsTests.swift
+++ b/PrusaStatusBarTests/PrinterDiagnosticsTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+@testable import PrusaStatusBar
+import Testing
+
+struct PrinterDiagnosticsTests {
+    private func makeClient(
+        handler: @escaping @Sendable (URLRequest) -> StubURLProtocol.Response
+    ) -> URLSessionPrusaLinkClient {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        StubURLProtocol.handler = handler
+        return URLSessionPrusaLinkClient(session: session) {
+            PrusaLinkConfiguration(baseURL: URL(string: "http://printer.local")!, apiKey: "test-key")
+        }
+    }
+
+    @Test
+    func copyableDiagnosticsRedactSensitiveResponses() async {
+        let client = makeClient { request in
+            let body: String
+            switch request.url?.path {
+            case "/api/v1/info":
+                body = #"{"hostname":"private.local","serial":"SN-123","nozzle_diameter":0.4}"#
+            case "/api/version":
+                body = #"{"hostname":"private.local","firmware":"6.4.2","printer":"17.0.0"}"#
+            case "/api/v1/status":
+                body = #"{"printer":{"state":"PRINTING","temp_nozzle":215,"note":"http://192.168.1.5/private"}}"#
+            case "/api/printer":
+                body = #"{"telemetry":{"material":"PLA"},"state":{"text":"Printing"}}"#
+            case "/api/v1/job":
+                body = #"{"file":{"display_name":"private-part.gcode","path":"/usb/private-part.gcode"}}"#
+            default:
+                return .response(status: 404, body: Data())
+            }
+            return .response(status: 200, body: Data(body.utf8))
+        }
+
+        let result = await client.fetchDiagnosticSnapshot()
+        guard case let .success(snapshot) = result else {
+            Issue.record("Expected diagnostics, got \(result)")
+            return
+        }
+
+        let report = snapshot.markdown(
+            showNozzleDiameter: true,
+            configuredNozzleDiameters: [],
+            effectiveNozzleDiameters: [0.4]
+        )
+        #expect(report.contains("private.local") == false)
+        #expect(report.contains("SN-123") == false)
+        #expect(report.contains("private-part.gcode") == false)
+        #expect(report.contains("192.168.1.5") == false)
+        #expect(report.contains("PRINTING"))
+        #expect(report.contains("0.4"))
+        #expect(report.contains("6.4.2"))
+        #expect(report.contains("17.0.0"))
+        #expect(report.contains("material"))
+    }
+
+    @Test
+    func diagnosticsAreAvailableWithoutAnActivePrint() async {
+        let client = makeClient { request in
+            switch request.url?.path {
+            case "/api/v1/status":
+                .response(status: 200, body: Data(#"{"printer":{"state":"IDLE"}}"#.utf8))
+            case "/api/v1/info":
+                .response(status: 200, body: Data(#"{"nozzle_diameter":0.4}"#.utf8))
+            case "/api/v1/job":
+                .response(status: 204, body: Data())
+            default:
+                .response(status: 404, body: Data())
+            }
+        }
+
+        let result = await client.fetchDiagnosticSnapshot()
+        guard case let .success(snapshot) = result else {
+            Issue.record("Expected diagnostics, got \(result)")
+            return
+        }
+        #expect(snapshot.jobJSON == nil)
+        let report = snapshot.markdown(
+            showNozzleDiameter: true,
+            configuredNozzleDiameters: [],
+            effectiveNozzleDiameters: [0.4]
+        )
+        #expect(report.contains("No active print job or endpoint unavailable."))
+        #expect(report.contains("Endpoint unavailable on this firmware."))
+    }
+}

--- a/PrusaStatusBarTests/UpdateCheckerTests.swift
+++ b/PrusaStatusBarTests/UpdateCheckerTests.swift
@@ -163,7 +163,9 @@ struct UpdateCheckerTests {
         // CountingReleaseClient's call count incrementing).
         for _ in 0 ..< 100 {
             let calls = await client.callCount
-            if calls >= 1 { break }
+            if calls >= 1 {
+                break
+            }
             try await Task.sleep(nanoseconds: 5_000_000)
         }
         checker.stop()

--- a/PrusaStatusBarTests/UserPreferencesTests.swift
+++ b/PrusaStatusBarTests/UserPreferencesTests.swift
@@ -110,6 +110,31 @@ struct UserPreferencesTests {
     }
 
     @Test
+    func configuredNozzleDiametersDefaultToAutomatic() {
+        let (prefs, _) = makePreferences()
+        #expect(prefs.configuredNozzleDiameters.isEmpty)
+    }
+
+    @Test
+    func configuredNozzleDiametersRoundTripAndClamp() {
+        let (prefs, _) = makePreferences()
+        prefs.configuredNozzleDiameters = [0.05, 0.6, 2.0, 0.25, 0.4, 0.8, 0.15, 0.5, 1.0]
+        #expect(prefs.configuredNozzleDiameters == [0.1, 0.6, 1.8, 0.25, 0.4, 0.8, 0.15, 0.5])
+        prefs.configuredNozzleDiameters = []
+        #expect(prefs.configuredNozzleDiameters.isEmpty)
+    }
+
+    @MainActor
+    @Test
+    func configuredNozzlesOverridePrusaLinkDiameter() {
+        let model = AppModel()
+        model.printerInfo = PrinterInfo(nozzleDiameter: 0.6)
+        #expect(model.effectiveNozzleDiameters == [0.6])
+        model.configuredNozzleDiameters = [0.6, 0.4]
+        #expect(model.effectiveNozzleDiameters == [0.6, 0.4])
+    }
+
+    @Test
     func prusaConnectUUIDIsNilWhenUnset() {
         let (prefs, _) = makePreferences()
         #expect(prefs.prusaConnectUUID == nil)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ https://github.com/user-attachments/assets/85046996-f5a1-4bcb-9e79-58f294655967
 - **Job details in the dropdown**: thumbnail of the current print, elapsed time, remaining time, and ETA.
 - **Two progress bar styles**: filament *Spool* or *Classic*, your call.
 - **Temperatures**: nozzle and bed, current vs target, with ring gauges.
-- **Optional extras**: show print speed, Z height, nozzle diameter, MMU status, and filament type in the dropdown when you want them.
+- **Optional extras**: show print speed, Z height, nozzle diameter, MMU status, and filament type in the dropdown when you want them. Multi-tool printers such as the XL and INDX can display a manually configured diameter for each of their tools.
 - **Job controls** without leaving the menu bar: pause, resume, stop.
 - **Detach to a floating window**: pop the dropdown out into a dedicated, always-available window with the same content. Useful for a second monitor or keeping the print visible while another app has focus.
 - **Quick links** to open PrusaLink (the local web UI) or PrusaConnect (the cloud dashboard). Buttons dim when the printer is unreachable or the link is not configured, and either button can be hidden if you do not use it.

--- a/project.yml
+++ b/project.yml
@@ -17,7 +17,7 @@ settings:
   base:
     SWIFT_VERSION: "5.10"
     MACOSX_DEPLOYMENT_TARGET: "14.0"
-    MARKETING_VERSION: "1.2.0"
+    MARKETING_VERSION: "1.3.0"
     # Default identity is ad-hoc ("-") so any contributor can build via Xcode
     # UI without provisioning a cert. The justfile recipes override
     # CODE_SIGN_IDENTITY / DEVELOPMENT_TEAM on the xcodebuild CLI: when an


### PR DESCRIPTION
<!--
Thanks for the PR. Please fill in the sections below.
-->

## Summary

Better support of Prusa XL and INDX with multiple heads

## Checklist

- [x] Tests added or updated (Swift Testing).
- [x] `just check` passes locally.
- [x] `just test` passes locally.
- [x] Prototype mode still builds (`just build-prototype`) when touching DI seams.
- [x] No PrusaLink API key written to `UserDefaults` or to logs.

## Summary by Sourcery

Improve multi-tool printer support and add privacy-conscious diagnostics for troubleshooting.

New Features:
- Support manual per-tool nozzle diameter configuration for multi-tool printers, including Prusa XL and INDX, with per-tool display in the status menu.
- Add a support diagnostics workflow that collects sanitized printer API data and copies a privacy-redacted report to the clipboard.

Enhancements:
- Use configured multi-tool nozzle diameters when available while preserving automatic single-nozzle reporting from PrusaLink.
- Include firmware, printer status, job, and material information in diagnostic reports while redacting sensitive device and network data.

Build:
- Bump the application marketing version to 1.3.0 and update the Xcode project configuration.

Documentation:
- Document multi-tool nozzle diameter support in the README.
- Add localized strings for multi-tool nozzle configuration and support diagnostics.

Tests:
- Add coverage for diagnostic report redaction and operation without an active print job.
- Add coverage for nozzle preference defaults, clamping, persistence, and model precedence.

Chores:
- Apply Swift formatting and simplify several SwiftUI view-builder constructs.